### PR TITLE
refactor: update useEffect hooks to return cleanup functions for even…

### DIFF
--- a/src/components/object-view/ObjectView.tsx
+++ b/src/components/object-view/ObjectView.tsx
@@ -44,22 +44,28 @@ function MapChildren(props: MapChildrenProps) {
     }
   }, [container]);
 
-  useEffect(()=>on("APPEND_SELECTION", (containers) => {
-    if(containers.includes(container)){
-      setSelected(true);
-    }
-  }), [container])
+  useEffect(() => {
+    return on("APPEND_SELECTION", (containers) => {
+      if (containers.includes(container)) {
+        setSelected(true);
+      }
+    });
+  }, [container]);
 
-  useEffect(()=>on("SET_SELECTION", (containers) => {
-    setSelected(containers.includes(container))
-  }), [container])
+  useEffect(() => {
+    return on("SET_SELECTION", (containers) => {
+      setSelected(containers.includes(container));
+    });
+  }, [container]);
 
   const event = `${container.kind.toUpperCase()}_SET_PROPERTY` as "SOURCE_SET_PROPERTY";
-  useEffect(() => on(event, ({uuid, property, value}) => {
-    if(uuid === container.uuid && property === "name") {
-      setName(value as string);
-    }
-  }), [container.uuid])
+  useEffect(() => {
+    return on(event, ({ uuid, property, value }) => {
+      if (uuid === container.uuid && property === "name") {
+        setName(value as string);
+      }
+    });
+  }, [container.uuid, event]);
 
   const label = <TreeItemLabel {...{ label: genericLabel, meta }} />;
   const roomLabel = <TreeItemLabel icon={<RoomIcon fontSize="inherit" />} {...{ label: genericLabel, meta }} />;

--- a/src/components/parameter-config/ParameterConfig.tsx
+++ b/src/components/parameter-config/ParameterConfig.tsx
@@ -64,7 +64,9 @@ const SolverOptionTitle = ({ uuid }) => {
 export const SolversTab = () => {
   const solvers = useSolver(useShallow(state=>state.withProperty(solver=>solver.kind)))
   const [index, setIndex] = useState(0);
-  useEffect(()=>on("NEW", ()=>setIndex(0)), [])
+  useEffect(() => {
+    return on("NEW", () => setIndex(0));
+  }, []);
   const [selectedSolverId, setSelectedSolverId] = useState("choose");
 
 
@@ -97,13 +99,19 @@ export const ObjectsTab = () => {
 
   const [selectedObjectId, setSelectedObjectId] = useState("choose");
 
-  useEffect(()=>on("NEW", ()=>setIndex(0)), [])
-  useEffect(()=>on("SET_SELECTION", (e)=>{
-    setSelectedObjectId(e[0].uuid)
-  }), [])
-  useEffect(()=>on("APPEND_SELECTION", (e)=>{
-    setSelectedObjectId(e[e.length-1].uuid)
-  }), [])
+  useEffect(() => {
+    return on("NEW", () => setIndex(0));
+  }, []);
+  useEffect(() => {
+    return on("SET_SELECTION", (e) => {
+      setSelectedObjectId(e[0].uuid);
+    });
+  }, []);
+  useEffect(() => {
+    return on("APPEND_SELECTION", (e) => {
+      setSelectedObjectId(e[e.length - 1].uuid);
+    });
+  }, []);
   const validSelection = selectedObjectId && objects.has(selectedObjectId);
   const ObjectParameterConfig = ObjectComponentMap.get(objects.get(selectedObjectId)!)!;
   return (
@@ -126,7 +134,9 @@ export const ObjectsTab = () => {
 
 export const ParameterConfig = () => {
   const [index, setIndex] = useState(0);
-  useEffect(()=>on("NEW", ()=>setIndex(0)), [])
+  useEffect(() => {
+    return on("NEW", () => setIndex(0));
+  }, []);
 
   const [selectedTabId, setSelectedTabId] = useState("renderer")
 

--- a/src/components/parameter-config/RT60Tab.tsx
+++ b/src/components/parameter-config/RT60Tab.tsx
@@ -77,9 +77,11 @@ const Export = ({uuid}: { uuid: string }) => {
   const {noResults} = useSolver(useShallow(state => pickProps(["noResults"], state.solvers[uuid] as RT60)));
   const [, forceUpdate] = useReducer((c) => c + 1, 0) as [never, () => void]
 
-  useEffect(()=>on("UPDATE_RT60", (e)=>{
-    forceUpdate();
-  }));
+  useEffect(() => {
+    return on("UPDATE_RT60", (e) => {
+      forceUpdate();
+    });
+  }, []);
 
   return(
     <PropertyRowFolder label="Export" open={open} onOpenClose={toggle}>

--- a/src/components/parameter-config/SurfaceTab.tsx
+++ b/src/components/parameter-config/SurfaceTab.tsx
@@ -92,12 +92,14 @@ const Transform = ({ uuid }: { uuid: string }) => {
 const MaterialButton = ({uuid}: {uuid: string}) => {
   const name = useContainer(state=>(state.containers[uuid] as Surface).acousticMaterial.name);
   const [, forceUpdate] = useReducer((c) => c + 1, 0) as [never, () => void]
-  useEffect(()=>on("ASSIGN_MATERIAL", ({ target })=>{
-    const surfaceInTarget = ensureArray(target).reduce((acc, curr) => acc || curr.uuid === uuid, false);
-    if(surfaceInTarget){
-      forceUpdate();
-    }
-  }), [uuid]);
+  useEffect(() => {
+    return on("ASSIGN_MATERIAL", ({ target }) => {
+      const surfaceInTarget = ensureArray(target).reduce((acc, curr) => acc || curr.uuid === uuid, false);
+      if (surfaceInTarget) {
+        forceUpdate();
+      }
+    });
+  }, [uuid]);
   return (
     <PropertyButton label="Material" buttonLabel={name} event="OPEN_MATERIAL_DRAWER" args={undefined} tooltip="Opens the material search screen"/>
   )

--- a/src/components/parameter-config/image-source-tab/ImageSourceTab.tsx
+++ b/src/components/parameter-config/image-source-tab/ImageSourceTab.tsx
@@ -108,11 +108,13 @@ const Calculation = ({ uuid }: { uuid: string}) => {
   const {sourceIDs, receiverIDs} = useSolver(useShallow(state => pickProps(["sourceIDs", "receiverIDs"], state.solvers[uuid] as ImageSourceSolver)));
   const disabled = !(sourceIDs.length > 0 && receiverIDs.length > 0);
   const [, forceUpdate] = useReducer((c) => c + 1, 0) as [never, () => void]
-  useEffect(()=>on("IMAGESOURCE_SET_PROPERTY", (e)=>{
-    if(e.uuid === uuid && (e.property === "sourceIDs" || e.property === "receiverIDs")){
-      forceUpdate();
-    }
-  }))
+  useEffect(() => {
+    return on("IMAGESOURCE_SET_PROPERTY", (e) => {
+      if (e.uuid === uuid && (e.property === "sourceIDs" || e.property === "receiverIDs")) {
+        forceUpdate();
+      }
+    });
+  }, [uuid]);
   return (
     <PropertyRowFolder label="Calculation" open={open} onOpenClose={toggle}>
       <PropertyNumberInput uuid={uuid} label="Maximum Order" property="maxReflectionOrderReset" tooltip="Sets the maximum reflection order"/>

--- a/src/components/results/LTPChart.tsx
+++ b/src/components/results/LTPChart.tsx
@@ -111,13 +111,15 @@ const Chart = ({ uuid, width = 400, height = 200, events = false, plotOrders }: 
     }, [data, plotOrders]);
 
 
-    useEffect(() => on("UPDATE_RESULT", (e) => {
-      if(e.uuid === uuid){
-        //@ts-ignore
-        setData(e.result.data);
-        // update();
-      }
-    }), [uuid])
+    useEffect(() => {
+      return on("UPDATE_RESULT", (e) => {
+        if (e.uuid === uuid) {
+          //@ts-ignore
+          setData(e.result.data);
+          // update();
+        }
+      });
+    }, [uuid]);
 
     const scalePadding = 60;
     const scaleWidth = width-scalePadding;
@@ -221,18 +223,22 @@ export const LTPChart = ({ uuid, width = 400, height = 300, events = false }: LT
   const [plotOrders, setPlotOrders] = useState(initialPlotOrders);
   const [order, setMaxOrder] = useState(info.maxOrder);
 
-  useEffect(() => on("UPDATE_RESULT", (e)=>{
-    if(e.uuid === uuid){
-      //@ts-ignore
-      setMaxOrder(e.result.info.maxOrder);
-    }
-  }), [uuid]);  
+  useEffect(() => {
+    return on("UPDATE_RESULT", (e) => {
+      if (e.uuid === uuid) {
+        //@ts-ignore
+        setMaxOrder(e.result.info.maxOrder);
+      }
+    });
+  }, [uuid]);
 
-  useEffect(() => on("IMAGESOURCE_SET_PROPERTY", (e)=>{
-    if(e.uuid === from && e.property === "plotOrders"){
+  useEffect(() => {
+    return on("IMAGESOURCE_SET_PROPERTY", (e) => {
+      if (e.uuid === from && e.property === "plotOrders") {
         setPlotOrders(e.value);
-    }
-  }), [uuid]);  
+      }
+    });
+  }, [from]);  
 
   const ordinalColorScale = useMemo(
     () => scaleOrdinal(

--- a/src/components/results/RT60Chart copy.tsx
+++ b/src/components/results/RT60Chart copy.tsx
@@ -91,13 +91,15 @@ const Chart = ({ uuid, width = 400, height = 200, events = false }: RT60ChartPro
     const [data, setData] = useState(_data);
 
 
-    useEffect(() => on("UPDATE_RESULT", (e) => {
-      if(e.uuid === uuid){
-        //@ts-ignore
-        setData(e.result.data);
-        // update();
-      }
-    }), [uuid])
+    useEffect(() => {
+      return on("UPDATE_RESULT", (e) => {
+        if (e.uuid === uuid) {
+          //@ts-ignore
+          setData(e.result.data);
+          // update();
+        }
+      });
+    }, [uuid]);
 
     const scalePadding = 60;
     const scaleWidth = width-scalePadding;
@@ -168,12 +170,14 @@ const Chart = ({ uuid, width = 400, height = 200, events = false }: RT60ChartPro
 export const RT60Chart = ({ uuid, width = 400, height = 300, events = false }: RT60ChartProps) => {
   const {name, info, from} = useResult(state=>pickProps(["name", "info", "from"], state.results[uuid] as Result<ResultKind.StatisticalRT60>));
 
-  useEffect(() => on("UPDATE_RESULT", (e)=>{
-    if(e.uuid === uuid){
-      //@ts-ignore
-      //setMaxOrder(e.result.info.maxOrder);
-    }
-  }), [uuid]);  
+  useEffect(() => {
+    return on("UPDATE_RESULT", (e) => {
+      if (e.uuid === uuid) {
+        //@ts-ignore
+        //setMaxOrder(e.result.info.maxOrder);
+      }
+    });
+  }, [uuid]);  
 
   return width < 10 ? null : (
     <VerticalContainer>

--- a/src/components/results/RT60Chart.tsx
+++ b/src/components/results/RT60Chart.tsx
@@ -163,12 +163,14 @@ export const Chart = ({
     range: [blue, green, darkgreen],
   });
 
-  useEffect(() => on("UPDATE_RESULT", (e) => {
-    if(e.uuid === uuid){
-      //@ts-ignore
-      setData(e.result.data);
-    }
-  }), [uuid])
+  useEffect(() => {
+    return on("UPDATE_RESULT", (e) => {
+      if (e.uuid === uuid) {
+        //@ts-ignore
+        setData(e.result.data);
+      }
+    });
+  }, [uuid]);
 
   const scalePadding = 60;
   const topPadding = 30; 


### PR DESCRIPTION
…t listeners

Optimized render loop ([lines 904-932](vscode-webview://0nvinfhljs09q739kcaal8ol7r66f1vk8v856cepndmvhiddlk1r/src/render/renderer.ts#L904-L932))
Before: requestAnimationFrame was called unconditionally every frame, and orientationControl.shouldRender = true was set inside the render block causing perpetual rendering. After:
Separated main scene and orientation control render decisions
Only continues 60fps animation loop when actively rendering
Falls back to 100ms polling when idle (10fps idle check instead of 60fps)