### PR TITLE
fix: replace hardcoded 343 m/s speed of sound in image source

### DIFF
--- a/src/compute/raytracer/image-source/__tests__/hardcoded-speed-of-sound.spec.ts
+++ b/src/compute/raytracer/image-source/__tests__/hardcoded-speed-of-sound.spec.ts
@@ -24,9 +24,10 @@ describe('Issue #41: Replace hardcoded 343 speed of sound', () => {
     expect(matches).toBeNull();
   });
 
-  test('ImageSourceSolver has a temperature property', () => {
+  test('ImageSourceSolver has a temperature property configurable via params', () => {
     expect(source).toContain('temperature: number');
-    expect(source).toContain('this.temperature = 20');
+    expect(source).toContain('temperature?: number');
+    expect(source).toMatch(/this\.temperature\s*=\s*params\.temperature/);
   });
 
   test('ImageSourceSolver has a speed of sound getter using ac.soundSpeed', () => {
@@ -40,11 +41,11 @@ describe('Issue #41: Replace hardcoded 343 speed of sound', () => {
     expect(ltpMatch).not.toBeNull();
   });
 
-  test('calculateImpulseResponse uses this.c', () => {
+  test('calculateImpulseResponse uses this.c (cached as local const)', () => {
     const irSection = source.match(/async calculateImpulseResponse[\s\S]*?^\s{4}\}/m);
     expect(irSection).not.toBeNull();
-    // Should use this.c, not a literal
-    expect(irSection![0]).toContain('this.c');
+    // Should cache this.c and use it, not a literal
+    expect(irSection![0]).toMatch(/const c = this\.c/);
     expect(irSection![0]).not.toMatch(/arrivalTime\(\s*343\s*\)/);
   });
 

--- a/src/compute/raytracer/image-source/index.ts
+++ b/src/compute/raytracer/image-source/index.ts
@@ -310,6 +310,7 @@ export interface ImageSourceSolverParams {
   plotOrders: number[];
   frequencies: number[];
   levelTimeProgression?: string;
+  temperature?: number;
 }
 
 const defaults = {
@@ -374,7 +375,7 @@ export class ImageSourceSolver extends Solver {
         this._plotOrders = params.plotOrders; 
         this.levelTimeProgression = params.levelTimeProgression || uuid();
         this.isHybrid = isHybrid;
-        this.temperature = 20;
+        this.temperature = params.temperature != null ? params.temperature : 20;
 
         this.impulseResponsePlaying = false; 
 
@@ -689,13 +690,14 @@ export class ImageSourceSolver extends Solver {
       if(this.sourceIDs.length === 0) throw Error("No sources have been assigned to the raytracer");
       if(this.validRayPaths?.length === 0) throw Error("No rays have been traced yet");
 
-      let sortedPath: ImageSourcePath[] | null = this.validRayPaths; 
-      sortedPath?.sort((a, b) => (a.arrivalTime(this.c) > b.arrivalTime(this.c)) ? 1 : -1);
+      const c = this.c;
+      let sortedPath: ImageSourcePath[] | null = this.validRayPaths;
+      sortedPath?.sort((a, b) => (a.arrivalTime(c) > b.arrivalTime(c)) ? 1 : -1);
 
       console.log(sortedPath);
 
       if(sortedPath != null){
-        const endTime = sortedPath[sortedPath.length - 1].arrivalTime(this.c)+0.05;
+        const endTime = sortedPath[sortedPath.length - 1].arrivalTime(c)+0.05;
         const endSample = sampleRate*endTime;
 
         let samples: Float32Array[] = [];
@@ -704,7 +706,7 @@ export class ImageSourceSolver extends Solver {
         }
 
         for(let i = 0; i<sortedPath.length; i++){
-          let t = sortedPath[i].arrivalTime(this.c);
+          let t = sortedPath[i].arrivalTime(c);
           let p = sortedPath[i].arrivalPressure(spls, this.frequencies);
 
           (Math.random() > 0.5) && (p=p.map(x=>-x)); 


### PR DESCRIPTION
## Summary
- Adds \`temperature\` property (default 20°C) and \`get c()\` getter using \`ac.soundSpeed(temperature)\`
- Replaces all 9 hardcoded \`343\` occurrences with the computed speed of sound
- Fixes a secondary bug in \`calculateLTP\` where the \`c\` parameter was accepted but then ignored (inner loop used \`343\` instead of \`c\`)

## Test plan
- [x] No hardcoded 343 values remain in the file
- [x] \`temperature\` property and \`c\` getter exist and work correctly
- [x] \`calculateLTP\` defaults to \`this.c\` and uses its parameter consistently
- [x] \`calculateImpulseResponse\` uses \`this.c\`
- [x] Event handler calls \`calculateLTP()\` without hardcoded value
- [x] \`soundSpeed(20)\` produces ~343 m/s, confirming backward compatibility
- [x] Speed of sound varies correctly with temperature
- [x] Hybrid solver interface still accepts speed as parameter

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)