### PR TITLE
feat: frequency-dependent scattering in ray tracer

### DIFF
--- a/src/compute/raytracer/__tests__/freq-dependent-scattering.spec.ts
+++ b/src/compute/raytracer/__tests__/freq-dependent-scattering.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Source-scanning tests for frequency-dependent scattering in the ray tracer.
+ *
+ * Phase 3 replaces the scalar _scatteringCoefficient with energy-weighted
+ * broadband scattering derived from surface.scatteringFunction(). These tests
+ * verify the source code has the expected structure without needing to
+ * instantiate the full Three.js/WebGL environment.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('frequency-dependent scattering', () => {
+  const raytracerSource = fs.readFileSync(
+    path.resolve(__dirname, '..', 'index.ts'),
+    'utf8'
+  );
+
+  const surfaceSource = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', '..', 'objects', 'surface.ts'),
+    'utf8'
+  );
+
+  const materialSource = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', '..', 'db', 'acoustic-material.ts'),
+    'utf8'
+  );
+
+  describe('traceRay', () => {
+    it('uses surface.scatteringFunction( not _scatteringCoefficient', () => {
+      // Extract the traceRay method body
+      const traceRayMatch = raytracerSource.match(/traceRay\(([\s\S]*?)\)\s*\{([\s\S]*?)^\s{2}\}/m);
+      expect(traceRayMatch).not.toBeNull();
+      const traceRayBody = traceRayMatch![0];
+
+      // Should use surface.scatteringFunction(, not _scatteringCoefficient
+      expect(traceRayBody).toContain('surface.scatteringFunction(');
+      expect(traceRayBody).not.toContain('_scatteringCoefficient');
+    });
+
+    it('derives scatterCoeffs from this.frequencies', () => {
+      expect(raytracerSource).toContain(
+        'this.frequencies.map(f => surface.scatteringFunction(f))'
+      );
+    });
+
+    it('computes energy-weighted broadband scattering', () => {
+      // Verify energy weighting: scatterCoeffs[f] * bandEnergy[f]
+      expect(raytracerSource).toContain('scatterCoeffs[f] * (bandEnergy[f] || 0)');
+      // Verify division by total energy
+      expect(raytracerSource).toContain('broadbandScattering /= totalEnergy');
+    });
+  });
+
+  describe('BRDF construction', () => {
+    it('uses this.scatteringFunction(freq) not hardcoded 0.1 in init()', () => {
+      // Find the init method — look for the BRDF construction in init
+      // The init method sets up scatteringCoefficient before BRDF
+      const brdfBlocks = surfaceSource.match(/new BRDF\(\{[\s\S]*?\}\)/g);
+      expect(brdfBlocks).not.toBeNull();
+
+      // All BRDF constructions should use scatteringFunction, not 0.1
+      brdfBlocks!.forEach(block => {
+        expect(block).toContain('this.scatteringFunction(freq)');
+        expect(block).not.toContain('diffusionCoefficient: 0.1');
+      });
+    });
+
+    it('does not contain any hardcoded diffusionCoefficient: 0.1', () => {
+      expect(surfaceSource).not.toContain('diffusionCoefficient: 0.1');
+    });
+  });
+
+  describe('calculateWithDiffuse', () => {
+    it('uses surface.scatteringFunction(frequency) not hardcoded 0.1', () => {
+      // Find the calculateWithDiffuse method body
+      const methodStart = raytracerSource.indexOf('calculateWithDiffuse');
+      expect(methodStart).toBeGreaterThan(-1);
+
+      // Extract a generous chunk of the method containing scatteredEnergy call
+      const methodChunk = raytracerSource.slice(methodStart, methodStart + 3000);
+
+      // Find the scatteredEnergy call within the method
+      const scatteredEnergyMatch = methodChunk.match(/scatteredEnergy\(([\s\S]*?)\)\s*\n/);
+      expect(scatteredEnergyMatch).not.toBeNull();
+
+      // The scatteredEnergy call should use surface.scatteringFunction(frequency)
+      expect(scatteredEnergyMatch![1]).toContain('surface.scatteringFunction(frequency)');
+      expect(scatteredEnergyMatch![1]).not.toMatch(/\b0\.1\b/);
+    });
+  });
+
+  describe('AcousticMaterial interface', () => {
+    it('includes optional scattering field', () => {
+      expect(materialSource).toContain('scattering?');
+    });
+  });
+});

--- a/src/compute/raytracer/index.ts
+++ b/src/compute/raytracer/index.ts
@@ -693,8 +693,17 @@ class RayTracer extends Solver {
           intersections[0].face &&
           rd.clone().sub(normal.clone().multiplyScalar(rd.dot(normal.clone())).multiplyScalar(2));
 
-        const scattering = (intersections[0].object.parent as Surface)._scatteringCoefficient;
-        if(probability(scattering)){
+        // compute energy-weighted broadband scattering for directional decision
+        const surface = intersections[0].object.parent as Surface;
+        const scatterCoeffs = this.frequencies.map(f => surface.scatteringFunction(f));
+        const totalEnergy = bandEnergy.reduce((a, b) => a + b, 0) || 1;
+        let broadbandScattering = 0;
+        for (let f = 0; f < this.frequencies.length; f++) {
+          broadbandScattering += scatterCoeffs[f] * (bandEnergy[f] || 0);
+        }
+        broadbandScattering /= totalEnergy;
+
+        if (probability(broadbandScattering)) {
           // Cosine-weighted (Lambertian) hemisphere sampling via rejection method
           let candidate: THREE.Vector3;
           do {
@@ -710,7 +719,6 @@ class RayTracer extends Solver {
         }
 
         // apply per-band reflection loss
-        const surface = intersections[0].object.parent as Surface;
         const newBandEnergy = this.frequencies.map((frequency, f) => {
           const e = bandEnergy[f];
           if (e == null) return 0;
@@ -1312,7 +1320,7 @@ class RayTracer extends Solver {
                     value: scatteredEnergy(
                       energytime.energy[index].value,
                       surface.absorptionFunction(frequency),
-                      0.1,
+                      surface.scatteringFunction(frequency),
                       asin(receiverRadius / d.length()),
                       theta
                     )

--- a/src/db/acoustic-material.ts
+++ b/src/db/acoustic-material.ts
@@ -13,6 +13,10 @@ export interface AcousticMaterial {
     "4000": number;
     "8000": number;
   };
+  scattering?: {
+    "63"?: number; "125"?: number; "250"?: number; "500"?: number;
+    "1000"?: number; "2000"?: number; "4000"?: number; "8000"?: number;
+  };
   nrc: number;
   source: string;
   description: string;

--- a/src/objects/__tests__/surface.spec.ts
+++ b/src/objects/__tests__/surface.spec.ts
@@ -706,7 +706,7 @@ describe('Surface', () => {
       (BRDF as jest.Mock).mockClear();
 
       const geometry = createMockGeometry();
-      const surface = new Surface('BRDFTest', {
+      new Surface('BRDFTest', {
         geometry,
         acousticMaterial: mockAcousticMaterial,
       });

--- a/src/objects/__tests__/surface.spec.ts
+++ b/src/objects/__tests__/surface.spec.ts
@@ -63,9 +63,9 @@ jest.mock('../../compute/acoustics/reflection-coefficient', () => ({
   default: jest.fn().mockReturnValue(0.5),
 }));
 
-// Mock scatteringFunction
+// Mock scatteringFunction — returns 0.42 to distinguish from old hardcoded 0.1
 jest.mock('../../compute/acoustics/scattering-function', () => ({
-  scatteringFunction: jest.fn().mockReturnValue((f: number) => 0.1),
+  scatteringFunction: jest.fn().mockReturnValue((f: number) => 0.42),
 }));
 
 // Mock TessellateModifier
@@ -697,6 +697,87 @@ describe('Surface', () => {
       // Should not throw
       surface.tessellatedMeshVisible = true;
       expect(surface.tessellatedMeshVisible).toBe(false);
+    });
+  });
+
+  describe('BRDF uses scatteringFunction', () => {
+    it('diffusionCoefficient comes from scatteringFunction not hardcoded 0.1', () => {
+      const { BRDF } = require('../../compute/raytracer/brdf');
+      (BRDF as jest.Mock).mockClear();
+
+      const geometry = createMockGeometry();
+      const surface = new Surface('BRDFTest', {
+        geometry,
+        acousticMaterial: mockAcousticMaterial,
+      });
+
+      // BRDF should have been called for each frequency band
+      expect(BRDF).toHaveBeenCalled();
+      // scatteringFunction mock returns 0.42 — verify BRDF gets that, not 0.1
+      const calls = (BRDF as jest.Mock).mock.calls;
+      calls.forEach((call: any[]) => {
+        expect(call[0].diffusionCoefficient).toBe(0.42);
+      });
+    });
+
+    it('setter also uses scatteringFunction for BRDF', () => {
+      const { BRDF } = require('../../compute/raytracer/brdf');
+      const geometry = createMockGeometry();
+      const surface = new Surface('BRDFTest', {
+        geometry,
+        acousticMaterial: mockAcousticMaterial,
+      });
+
+      (BRDF as jest.Mock).mockClear();
+
+      // Re-assign material to trigger setter
+      const newMaterial: AcousticMaterial = {
+        ...mockAcousticMaterial,
+        uuid: 'new-material-uuid',
+      };
+      surface.acousticMaterial = newMaterial;
+
+      expect(BRDF).toHaveBeenCalled();
+      const calls = (BRDF as jest.Mock).mock.calls;
+      calls.forEach((call: any[]) => {
+        expect(call[0].diffusionCoefficient).toBe(0.42);
+      });
+    });
+  });
+
+  describe('material scattering data', () => {
+    it('material with scattering overrides ISO lookup', () => {
+      const interpolateAlpha = require('../../compute/acoustics/interpolate-alpha').default;
+      (interpolateAlpha as jest.Mock).mockClear();
+
+      const geometry = createMockGeometry();
+      const surface = new Surface('ScatterTest', {
+        geometry,
+        acousticMaterial: mockAcousticMaterial,
+      });
+
+      const materialWithScattering: AcousticMaterial = {
+        ...mockAcousticMaterial,
+        uuid: 'scatter-material-uuid',
+        scattering: {
+          '125': 0.05,
+          '250': 0.1,
+          '500': 0.2,
+          '1000': 0.4,
+          '2000': 0.6,
+          '4000': 0.8,
+        },
+      };
+
+      surface.acousticMaterial = materialWithScattering;
+
+      // interpolateAlpha should be called with the scattering values
+      // (once for absorption, once for scattering)
+      const calls = (interpolateAlpha as jest.Mock).mock.calls;
+      const scatteringCall = calls.find(
+        (call: any[]) => Array.isArray(call[0]) && call[0].includes(0.2) && call[0].includes(0.8)
+      );
+      expect(scatteringCall).toBeDefined();
     });
   });
 

--- a/src/objects/surface.ts
+++ b/src/objects/surface.ts
@@ -379,16 +379,6 @@ class Surface extends Container {
     this.reflectionFunction = (freq, theta) => reflectionCoefficient(this.absorptionFunction(freq), theta);
     this.scatteringCoefficient = props.scatteringCoefficient || defaults.scatteringCoefficient;
     this.acousticMaterial = props.acousticMaterial;
-    this.brdf = [] as BRDF[];
-    const freqKeys = Object.keys(this.acousticMaterial.absorption).map(Number);
-    freqKeys.forEach(freq => {
-      this.brdf.push(
-        new BRDF({
-          absorptionCoefficient: (this.acousticMaterial.absorption as Record<string, number>)[String(freq)],
-          diffusionCoefficient: this.scatteringFunction(freq)
-        })
-      );
-    });
     this.getArea();
 
     this.edgeLoop = this.calculateEdgeLoop();

--- a/src/objects/surface.ts
+++ b/src/objects/surface.ts
@@ -380,14 +380,15 @@ class Surface extends Container {
     this.scatteringCoefficient = props.scatteringCoefficient || defaults.scatteringCoefficient;
     this.acousticMaterial = props.acousticMaterial;
     this.brdf = [] as BRDF[];
-    for (const key in this.acousticMaterial.absorption) {
+    const freqKeys = Object.keys(this.acousticMaterial.absorption).map(Number);
+    freqKeys.forEach(freq => {
       this.brdf.push(
         new BRDF({
-          absorptionCoefficient: (this.acousticMaterial.absorption as Record<string, number>)[key],
-          diffusionCoefficient: 0.1
+          absorptionCoefficient: (this.acousticMaterial.absorption as Record<string, number>)[String(freq)],
+          diffusionCoefficient: this.scatteringFunction(freq)
         })
       );
-    }
+    });
     this.getArea();
 
     this.edgeLoop = this.calculateEdgeLoop();
@@ -615,15 +616,22 @@ class Surface extends Container {
     this.absorption = freq.map((x) => (this._acousticMaterial.absorption as Record<string, number>)[String(x)]);
     this.absorptionFunction = interpolateAlpha(this.absorption, freq);
     this.reflectionFunction = (freq, theta) => reflectionCoefficient(this.absorptionFunction(freq), theta);
+    if (material.scattering) {
+      const scFreqs = Object.keys(material.scattering).map(Number);
+      const scVals = scFreqs.map(f => material.scattering![String(f) as keyof typeof material.scattering]!);
+      this.scatteringFunction = interpolateAlpha(scVals, scFreqs);
+      this._scatteringCoefficient = this.scatteringFunction(500);
+    }
     this.brdf = [] as BRDF[];
-    for (const key in this.acousticMaterial.absorption) {
+    const freqKeys = Object.keys(this.acousticMaterial.absorption).map(Number);
+    freqKeys.forEach(freq => {
       this.brdf.push(
         new BRDF({
-          absorptionCoefficient: (this.acousticMaterial.absorption as Record<string, number>)[key],
-          diffusionCoefficient: 0.1
+          absorptionCoefficient: (this.acousticMaterial.absorption as Record<string, number>)[String(freq)],
+          diffusionCoefficient: this.scatteringFunction(freq)
         })
       );
-    }
+    });
   }
   get displayVertexNormals() {
     return this.vertexNormals.visible;


### PR DESCRIPTION
## Summary

- **Frequency-dependent scattering in `traceRay`**: Replace scalar `_scatteringCoefficient` with energy-weighted broadband scattering derived from `surface.scatteringFunction()` per Vorländer's probabilistic single-ray approach
- **Fix hardcoded `diffusionCoefficient: 0.1`** in BRDF construction (both `init()` and `acousticMaterial` setter) and in `calculateWithDiffuse` — now uses `surface.scatteringFunction(freq)` 
- **Add optional `scattering` field** to `AcousticMaterial` interface for per-band scattering data from materials, wired through `interpolateAlpha` in the setter

Closes #62

## Test plan

- [x] New source-scanning tests in `freq-dependent-scattering.spec.ts` verify `traceRay` uses `scatteringFunction`, energy-weighted broadband scattering, BRDF uses scatteringFunction, and `calculateWithDiffuse` uses per-frequency scattering
- [x] Updated `surface.spec.ts` verifies BRDF gets scatteringFunction output (not 0.1) in both init and setter paths, and material scattering data overrides ISO lookup
- [x] All existing tests pass (3 pre-existing UI test failures unrelated)
- [x] `tsc --noEmit` clean (1 pre-existing error in `rt/index.ts` unrelated)
- [ ] Manual: run raytracer, verify scattering still works and higher frequencies scatter more

🤖 Generated with [Claude Code](https://claude.com/claude-code)