### PR TITLE
feat: convergence monitoring, Russian Roulette termination, and stratified sampling

### DIFF
--- a/src/components/parameter-config/RayTracerTab.tsx
+++ b/src/components/parameter-config/RayTracerTab.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import RayTracer from "../../compute/raytracer";
-import { ConvergenceMetrics } from "../../compute/raytracer";
 import PropertyRowFolder from "./property-row/PropertyRowFolder";
 import PropertyRow from "./property-row/PropertyRow";
 import PropertyRowLabel from "./property-row/PropertyRowLabel";


### PR DESCRIPTION
## Summary

Closes #66

- **Convergence monitoring with auto-stop (7a):** Tracks per-band T30 estimates via Schroeder backward integration of energy histograms accumulated during simulation. Uses Welford's online algorithm for running mean/variance. Auto-stops when max coefficient of variation across frequency bands falls below configurable `convergenceThreshold` (default 1%). Manual stop still works at any time.

- **Russian Roulette unbiased ray termination (7b):** Replaces the hard energy cutoff (`1/2^16`) with probabilistic Russian Roulette. When a ray's max band energy drops below `rrThreshold` (default 0.1), it survives with probability proportional to its energy. Surviving rays are boosted by `1/survivalProbability` to preserve the unbiased energy estimate. The `reflectionOrder` limit is preserved as a safety bound.

- **Stratified hemisphere sampling (7c):** Replaces purely random angle generation with stratified (jittered) sampling. `stepStratified()` divides the source hemisphere into a grid of strata and generates one jittered ray per stratum per batch. Fixes the cube-normalized direction bias in `quickEstimateStep` with proper rejection sampling.

- **UI:** New "Convergence" section in the RayTracer panel with auto-stop toggle, convergence threshold input, RR threshold input, and live convergence ratio / estimated T30 display.

## Test plan

- [x] 26 new source-scanning tests covering all acceptance criteria (convergence metrics structure, RR replacing hard cutoff, survival probability boost, stratified sampling grid, quickEstimate bias fix)
- [x] Russian Roulette unbiasedness verified statistically (100k trials, mean energy matches expected value)
- [x] Stratified vs random coverage variance comparison (stratified produces lower variance)
- [x] All 80 existing test suites pass (3 pre-existing failures unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)