### PR TITLE
fix(css): restore sans-serif UI font

### DIFF
--- a/src/components/workbench/workbenchTheme.css
+++ b/src/components/workbench/workbenchTheme.css
@@ -11,7 +11,18 @@
 /* Font and sizing to match MUI compact theme */
 .flexlayout__layout {
   --font-size: 13px;
-  --font-family: 'Segoe UI', 'Roboto', 'Arial', sans-serif;
+  /* Shares the app-wide stack from css/styles.css, with a literal fallback in
+     case flexlayout's styles are consumed without it. */
+  --font-family: var(
+    --cram-font-family,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    'Helvetica Neue',
+    Arial,
+    sans-serif
+  );
   /* v0.9 replaced the global `splitterSize` model attribute with a CSS var */
   --splitter-size: 4px;
 }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1,7 +1,23 @@
 /* @import url(https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap); */
-@import url(https://fonts.googleapis.com/css?family=Lato:300,400,700,300italic,400italic);
+
+/*
+ * The UI font stack, matching the MUI theme so unstyled elements agree with
+ * Typography.
+ *
+ * This previously pulled Lato from Google Fonts and declared `font-family:
+ * "Lato"` with no fallback. Host apps block that request under their CSP, so
+ * Lato never arrived and every element the rules below match fell back to the
+ * browser default — a serif face — while MUI components kept the sans stack.
+ * That is what produced serif flexlayout tab labels, "No Results Yet!" and the
+ * Heap/FPS readout over the canvas.
+ */
+:root {
+  --cram-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+}
+
 .App {
-  font-family: "Lato", sans-serif;
+  font-family: var(--cram-font-family);
   text-align: center;
 }
 body {
@@ -17,7 +33,7 @@ body {
 }
 
 * {
-  font-family: "Lato";
+  font-family: var(--cram-font-family);
 }
 
 #renderer-canvas{


### PR DESCRIPTION
Several parts of the UI render in a serif face: flexlayout tab labels, "No Results Yet!" in the results panel, and the Heap/FPS readout over the canvas.

## Cause

`src/css/styles.css` carried a universal rule with **no fallback**, depending on a webfont pulled from Google Fonts:

```css
@import url(https://fonts.googleapis.com/css?family=Lato:...);
* { font-family: "Lato"; }
```

Host apps block that request under their CSP, so Lato never loaded — and with no fallback in the declaration, every element the rule matched dropped to the browser's default serif. MUI components were unaffected because their emotion classes outrank `*` and carry the theme's own sans stack, which is why the app looked half-right rather than obviously broken.

## Evidence

Measured in the running app rather than inferred:

- `document.styleSheets` contained **zero** Google Fonts entries — the `@import` never landed.
- Text set in `Lato` measured **327.02px**; the same text in a deliberately nonexistent family `__NoSuchFont__` measured **327.02px**. Identical, so `Lato` was resolving to nothing. Arial measured 366.38px for comparison.

## Fix

Introduces `--cram-font-family` holding the same stack the MUI theme uses, applies it to `*` and `.App`, and drops the now-unused external font request.

Using the MUI stack rather than a bare `Arial` means unstyled elements resolve to the *same* font `Typography` already uses, instead of introducing a second sans face. Arial remains in the stack as the conventional fallback.

`workbenchTheme.css` feeds the same variable into flexlayout's `--font-family`, keeping a literal fallback in case those styles are ever consumed without `styles.css`.

## Verification

Confirmed in the browser against project-varese — flexlayout root, tab buttons, "No Results Yet!" and the Heap/FPS label all now compute to the sans stack, and render accordingly.

Also swept for other fallback-less `font-family` declarations in CSS and inline `fontFamily` in components: there are none, so these were the only affected paths.

**2226 tests / 104 files** pass, lint and typecheck clean. CSS-only change; no behavioural surface.

Split out of #87, which is unrelated feature work. No file overlap between the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
