### PR TITLE
fix(surface): pass the receiving plane to plane.fromPoints

### DIFF
--- a/src/objects/__tests__/surface.spec.ts
+++ b/src/objects/__tests__/surface.spec.ts
@@ -32,28 +32,30 @@ vi.mock('../../store', () => ({
   setContainerProperty: vi.fn(),
 }));
 
-// Mock CSG
-vi.mock('../../compute/csg', () => ({
-  __esModule: true,
-  default: {
+// CSG, backed by the real @jscad/modeling.
+//
+// The genuine module (src/compute/csg -> ../modeling -> v2.ts) cannot be imported here:
+// v2.ts top-level-awaits a browser URL (window.location.origin + '/compute/modeling/
+// jscad-modeling-bundle.js') that jsdom cannot resolve. So we rebuild the small slice of
+// that surface which Surface actually touches on top of the real package, mirroring the
+// wrappers in v2.ts. Stubbing these with fixed return values instead would hide real
+// defects — a stubbed plane.fromPoints previously masked a call site that omitted the
+// out-parameter and silently produced degenerate planes.
+vi.mock('../../compute/csg', async () => {
+  const { maths, geometries } = await vi.importActual<any>('@jscad/modeling');
+  const csg = {
     math: {
+      ...maths,
+      // v2.ts layers fromArray on top of the real vec3
       vec3: {
-        fromArray: vi.fn((arr: number[]) => arr),
-      },
-      plane: {
-        fromPoints: vi.fn(() => [0, 0, 1, 0]),
+        ...maths.vec3,
+        fromArray: (arr: number[]) => maths.vec3.fromValues(arr[0], arr[1], arr[2]),
       },
     },
-    geometry: {
-      poly3: {
-        fromPointsAndPlane: vi.fn(() => ({
-          vertices: [],
-          plane: [0, 0, 1, 0],
-        })),
-      },
-    },
-  },
-}));
+    geometry: { ...geometries },
+  };
+  return { __esModule: true, default: csg, ...csg };
+});
 
 // Mock BRDF
 vi.mock('../../compute/raytracer/brdf', () => ({
@@ -200,6 +202,54 @@ describe('Surface', () => {
 
       expect(Array.isArray(surface._triangles)).toBe(true);
       expect(surface._triangles.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('polygon', () => {
+    const buildSurface = () =>
+      new Surface('Poly', {
+        geometry: createMockGeometry(),
+        acousticMaterial: mockAcousticMaterial,
+      });
+
+    it('derives a unit-length plane normal from the edge loop', () => {
+      const [nx, ny, nz] = buildSurface().polygon.plane;
+
+      expect(Math.hypot(nx, ny, nz)).toBeCloseTo(1, 10);
+    });
+
+    it('agrees with the surface normal', () => {
+      const surface = buildSurface();
+      const [nx, ny, nz] = surface.polygon.plane;
+
+      expect(nx).toBeCloseTo(surface.normal.x, 10);
+      expect(ny).toBeCloseTo(surface.normal.y, 10);
+      expect(nz).toBeCloseTo(surface.normal.z, 10);
+    });
+
+    // Regression: plane.fromPoints takes the receiving plane as its first argument. The
+    // call sites used to omit it, so a vertex was used as the output buffer and rewritten
+    // in place as a 4-component plane.
+    it('leaves every vertex a 3-component point', () => {
+      const { vertices } = buildSurface().polygon;
+
+      expect(vertices.length).toBeGreaterThan(2);
+      vertices.forEach((vertex) => expect(vertex).toHaveLength(3));
+    });
+
+    it('keeps the vertices equal to the edge loop', () => {
+      const surface = buildSurface();
+
+      expect(surface.polygon.vertices).toEqual(surface.edgeLoop.map((v) => [v.x, v.y, v.z]));
+    });
+
+    it('places every vertex on the plane', () => {
+      const surface = buildSurface();
+      const [nx, ny, nz, w] = surface.polygon.plane;
+
+      surface.polygon.vertices.forEach((vertex) => {
+        expect(vertex[0] * nx + vertex[1] * ny + vertex[2] * nz - w).toBeCloseTo(0, 10);
+      });
     });
   });
 

--- a/src/objects/surface.ts
+++ b/src/objects/surface.ts
@@ -382,7 +382,10 @@ class Surface extends Container {
     this.edgeLoop = this.calculateEdgeLoop();
 
     const points = this.edgeLoop.map((x) => csg.math.vec3.fromArray([x.x, x.y, x.z]));
-    const plane = csg.math.plane.fromPoints(points[0], points[1], points[2]);
+    // NOTE: plane.fromPoints takes the receiving plane as its first argument. Omitting it
+    // makes the first vertex the output buffer, which both corrupts that vertex and yields
+    // a degenerate plane (only two vertices are left to derive the normal from).
+    const plane = csg.math.plane.fromPoints(csg.math.plane.create(), points[0], points[1], points[2]);
     // console.log("points", points);
     // console.log("plane", plane);
     this.polygon = csg.geometry.poly3.fromPointsAndPlane(points, plane);
@@ -393,7 +396,7 @@ class Surface extends Container {
 
     if (normalAlmostEqualsPlane(this.normal, this.polygon.plane)) {
       // console.warn(new Error(`Surface '${this.name}' has a normal vector issue`));
-      this.polygon = csg.geometry.poly3.fromPointsAndPlane(points, csg.math.plane.fromPoints(points[2], points[1], points[0]));
+      this.polygon = csg.geometry.poly3.fromPointsAndPlane(points, csg.math.plane.fromPoints(csg.math.plane.create(), points[2], points[1], points[0]));
       // console.log("flipping", this.normal.toArray(), [...this.polygon.plane]);
         if (normalAlmostEqualsPlane(this.normal, this.polygon.plane)) {
           // console.log("still not equal", this.normal.toArray(), [...this.polygon.plane]);


### PR DESCRIPTION
## Summary

`plane.fromPoints` in `@jscad/modeling` takes the receiving plane as its **first** argument. Both call sites in `Surface` omitted it, so the first vertex was used as the output buffer.

Two things went wrong at once:

- the vertex was **corrupted in place**, rewritten as a 4-component plane
- only two vertices were left to derive the normal from, yielding a degenerate `[0,0,0,0]` plane for **every** surface

Because the degenerate plane never matched the surface normal, the flip branch always ran — and its corrective call omitted the argument too, clobbering a second vertex.

Reproduced against the installed `@jscad/modeling@2.13.0` with a tilted quad:

```
points fresh      : [[0,0,0],[2,0,1],[2,3,1],[0,3,0]]
plane (line 405)  : [0,0,0,0]          ← should be [-0.447,0,0.894,0]
points AFTER 405  : [[0,0,0,0],...]    ← points[0] clobbered into the out-param
takes flip branch : true
points AFTER 416  : [[0,0,0,0],[2,0,1],[0,0,0,0],[0,3,0]]  ← points[2] clobbered too
```

## Impact

`reflectPointAcrossSurface` (`compute/raytracer/image-source/index.ts`) uses `polygon.vertices[0]` as a point on the plane to derive `d`. It was reading `(0,0,0)`, so `localToWorld((0,0,0))` yielded the surface's local origin instead of an actual vertex — image-source mirroring resolved against a shifted plane wherever that origin wasn't already on it.

The exact magnitude depends on each surface's transform, which I did not trace exhaustively. The polygon corruption itself is confirmed directly.

## Why the call sites, not the wrapper

Every other caller — `compute/modeling/bsp.ts:59,574` and `compute/raytracer/split-polygon.ts:81` — already passes `plane.create()` correctly. Making the `v2.ts` wrapper allocate internally would have broken all three. `surface.ts` was the lone outlier, so the fix belongs there.

Notably `v2.ts`'s own `fromPointsRandom` helper already supplies `plane.create()` — the correct pattern was in the file, just not applied to the pass-through.

## Testing

The surface spec stubbed `plane.fromPoints` with a fixed `[0,0,1,0]`, masking this across all its tests. The mock is now backed by the **real** `@jscad/modeling`.

Full un-mocking isn't possible: `compute/modeling/v2.ts` top-level-awaits `window.location.origin + '/compute/modeling/jscad-modeling-bundle.js'`, which jsdom can't resolve. So the mock rebuilds only the slice `Surface` touches, mirroring v2.ts's `fromArray` wrapper — real math semantics, no browser loader.

Five new `polygon` assertions cover the invariants the bug violated. **Four of the five fail against the previous code:**

```
× derives a unit-length plane normal        expected +0 to be close to 1
× agrees with the surface normal            expected +0 to be close to 1
× leaves every vertex a 3-component point   expected [+0,+0,+0,+0] to have length 3 but got 4
× keeps the vertices equal to the edge loop
```

The fifth ("places every vertex on the plane") passes vacuously against the buggy code — with a zero normal and `w=0` the dot product is trivially 0. It's kept as a genuine invariant, but the other four are what pin the regression.

Full suite on this base: **93 files, 1870 tests, 0 failures.** `tsc --noEmit` clean on both touched files.

## Follow-up (not in this PR)

`v2.ts` passes through many other out-first jscad functions the same way (`plane.flip`, `plane.transform`, `line3.fromPoints`, the `vec3`/`mat4` operations). I checked the live call sites and they use the out-first form correctly, so this was the only instance — but the footgun is structural and worth a sweep if that compatibility layer grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
