### PR TITLE
fix(dxf): import polyface quads and attribute parse failures

### DIFF
--- a/src/import-handlers/__tests__/dxf.spec.ts
+++ b/src/import-handlers/__tests__/dxf.spec.ts
@@ -1,0 +1,151 @@
+import { dxf } from '../dxf';
+
+vi.mock('three', async () => await vi.importActual('../../__mocks__/three'));
+
+// Surface/Room/Container drag in the renderer and store machinery; the import path only
+// needs them as sinks, so capture what they are handed instead.
+const createdSurfaces: Array<{ name: string; positions: number[] }> = [];
+
+vi.mock('../../objects/surface', () => ({
+  __esModule: true,
+  default: vi.fn().mockImplementation(function (this: any, name: string, props: any) {
+    this.name = name;
+    createdSurfaces.push({
+      name,
+      positions: Array.from(props.geometry.getAttribute('position').array as Float32Array),
+    });
+  }),
+}));
+
+vi.mock('../../objects/container', () => ({
+  __esModule: true,
+  default: vi.fn().mockImplementation(function (this: any, name: string) {
+    this.name = name;
+    this.children = [];
+    this.add = (child: unknown) => this.children.push(child);
+  }),
+}));
+
+vi.mock('../../objects/room', () => ({
+  __esModule: true,
+  default: vi.fn().mockImplementation(function (this: any, name: string, props: any) {
+    this.name = name;
+    this.surfaces = props.surfaces;
+  }),
+}));
+
+vi.mock('../../store/material-store', () => ({
+  useMaterial: {
+    getState: () => ({ materials: new Map([['m', { uuid: 'm', material: 'Test' }]]) }),
+  },
+}));
+
+// --- DXF construction helpers -------------------------------------------------
+
+const group = (pairs: Array<[number, string | number]>) =>
+  pairs.map(([code, value]) => `${code}\n${value}`).join('\n') + '\n';
+
+/** A polyface mesh position vertex (flag 192). */
+const meshVertex = (x: number, y: number, z: number) =>
+  group([[0, 'VERTEX'], [8, 'walls'], [10, x], [20, y], [30, z], [70, 192]]);
+
+/** A polyface face record (flag 128); indices are 1-based, `d` omitted for triangles. */
+const faceRecord = (a: number, b: number, c: number, d?: number) => {
+  const pairs: Array<[number, string | number]> = [
+    [0, 'VERTEX'], [8, 'walls'], [10, 0], [20, 0], [30, 0], [70, 128],
+    [71, a], [72, b], [73, c],
+  ];
+  if (d !== undefined) pairs.push([74, d]);
+  return group(pairs);
+};
+
+const polyfaceDxf = (vertices: string[], faces: string[]) =>
+  group([[0, 'SECTION'], [2, 'ENTITIES']]) +
+  group([[0, 'POLYLINE'], [8, 'walls'], [66, 1], [70, 64], [71, vertices.length], [72, faces.length]]) +
+  vertices.join('') +
+  faces.join('') +
+  group([[0, 'SEQEND']]) +
+  group([[0, 'ENDSEC']]) +
+  group([[0, 'EOF']]);
+
+const unitQuad = [meshVertex(0, 0, 0), meshVertex(1, 0, 0), meshVertex(1, 1, 0), meshVertex(0, 1, 0)];
+
+describe('dxf import handler', () => {
+  beforeEach(() => {
+    createdSurfaces.length = 0;
+  });
+
+  describe('polyface faces', () => {
+    it('splits a quad face into two triangles', () => {
+      // Regression: only faceA/B/C were read, so the second triangle of every quad was
+      // dropped and the face imported as a hole.
+      dxf(polyfaceDxf(unitQuad, [faceRecord(1, 2, 3, 4)]));
+
+      expect(createdSurfaces).toHaveLength(1);
+      expect(createdSurfaces[0].positions).toHaveLength(18); // 2 triangles x 3 verts x 3 coords
+    });
+
+    it('emits one triangle for a triangular face', () => {
+      dxf(polyfaceDxf(unitQuad.slice(0, 3), [faceRecord(1, 2, 3)]));
+
+      expect(createdSurfaces[0].positions).toHaveLength(9);
+    });
+
+    it('does not add a degenerate triangle when the fourth index repeats the third', () => {
+      dxf(polyfaceDxf(unitQuad.slice(0, 3), [faceRecord(1, 2, 3, 3)]));
+
+      expect(createdSurfaces[0].positions).toHaveLength(9);
+    });
+
+    it('covers all four corners of a quad', () => {
+      dxf(polyfaceDxf(unitQuad, [faceRecord(1, 2, 3, 4)]));
+
+      const p = createdSurfaces[0].positions;
+      const corners = new Set<string>();
+      for (let i = 0; i < p.length; i += 3) corners.add(`${p[i]},${p[i + 1]},${p[i + 2]}`);
+
+      expect(corners).toEqual(new Set(['0,0,0', '1,0,0', '1,1,0', '0,1,0']));
+    });
+
+    it('treats negative indices as visible-edge flags, not distinct vertices', () => {
+      dxf(polyfaceDxf(unitQuad, [faceRecord(-1, 2, -3, 4)]));
+
+      const p = createdSurfaces[0].positions;
+      expect(p).toHaveLength(18);
+      expect(p.every((n) => Number.isFinite(n))).toBe(true);
+    });
+  });
+
+  describe('parse failures', () => {
+    it('throws a descriptive error for input the parser rejects', () => {
+      expect(() => dxf('this is not a dxf file')).toThrow(/Could not (parse|read) DXF file/);
+    });
+
+    it('throws rather than returning an empty room when there is no ENTITIES section', () => {
+      const noEntities =
+        group([[0, 'SECTION'], [2, 'HEADER']]) + group([[0, 'ENDSEC']]) + group([[0, 'EOF']]);
+
+      expect(() => dxf(noEntities)).toThrow(/Could not read DXF file/);
+    });
+
+    it('names the file type in the message so the failure is attributable', () => {
+      let message = '';
+      try {
+        dxf('this is not a dxf file');
+      } catch (err) {
+        message = err instanceof Error ? err.message : String(err);
+      }
+
+      expect(message).toMatch(/DXF/);
+    });
+  });
+
+  describe('layers', () => {
+    it('groups surfaces into a container named for the layer', () => {
+      const room: any = dxf(polyfaceDxf(unitQuad, [faceRecord(1, 2, 3, 4)]));
+
+      expect(room.surfaces).toHaveLength(1);
+      expect(room.surfaces[0].name).toBe('walls');
+    });
+  });
+});

--- a/src/import-handlers/dxf.ts
+++ b/src/import-handlers/dxf.ts
@@ -16,8 +16,27 @@ const makeBufferGeometry = (position: number[], _normals?: number[], _texCoords?
 
 export function dxf(data: string){
   const defaultMaterial = [...useMaterial.getState().materials.values()][0];
-  const parsedData: unknown = new DxfParser().parseSync(data);
+
+  // dxf-parser throws a bare scanner error on any group code it doesn't recognise, and
+  // returns null for input it can't make sense of at all. Both callers invoke this from an
+  // async handler with no catch, so an unguarded failure surfaces as nothing whatsoever —
+  // no room, no message. Attribute the failure instead.
+  let parsedData: unknown;
+  try {
+    parsedData = new DxfParser().parseSync(data);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`Could not parse DXF file: ${detail}`);
+  }
+  if (!parsedData) {
+    throw new Error("Could not parse DXF file: the parser returned no data.");
+  }
+
   const parsed = parsedData as Dxf;
+  if (!Array.isArray(parsed.entities)) {
+    throw new Error("Could not read DXF file: no ENTITIES section was found.");
+  }
+
   const layerMap = new Map<string, Container>();
   parsed.entities.filter(x=>x.type==="POLYLINE").forEach((polyline,i)=>{
     const _material = polyline.materialObjectHandle;
@@ -30,7 +49,17 @@ export function dxf(data: string){
     const indices = [] as number[][];
     polyline.vertices.forEach(vertex=>{
       if(vertex["faceA"]){
-        indices.push([vertex["faceA"]!, vertex["faceB"]!, vertex["faceC"]!].map(Math.abs).map(x=>x-1));
+        // Face indices are 1-based, and negative when the edge leading away from that
+        // vertex is invisible — so take the magnitude before converting to 0-based.
+        const [a, b, c, d] = [vertex.faceA, vertex.faceB, vertex.faceC, vertex.faceD]
+          .map(index => (index ? Math.abs(index) - 1 : -1));
+        indices.push([a, b, c]);
+        // A polyface quad carries a fourth index (group code 74); triangles leave it
+        // absent, zero, or repeating the third vertex. Without this the second half of
+        // every quad was dropped, leaving a hole.
+        if (d >= 0 && d !== c) {
+          indices.push([a, c, d]);
+        }
       } else {
         vertices.push([vertex.x,vertex.y,vertex.z!]);
       }
@@ -134,6 +163,8 @@ export interface Vertex {
   faceA?:                number;
   faceB?:                number;
   faceC?:                number;
+  /** Fourth index of a polyface quad (group code 74); absent on triangular faces. */
+  faceD?:                number;
 }
 
 export type VertexType = "VERTEX";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -471,12 +471,25 @@ messenger.addMessageHandler("IMPORT_FILE", (acc, ...args) => {
     if (allowed[fileType(file.name)]) {
       const objectURL = URL.createObjectURL(file);
       switch (fileType(file.name)) {
-        case "dxf": 
+        case "dxf":
         {
           const result = await (await fetch(objectURL)).text();
-          const room = importHandlers.dxf(result);
-          emit("ADD_ROOM", room);
-          console.log(room);
+          try {
+            const room = importHandlers.dxf(result);
+            emit("ADD_ROOM", room);
+            console.log(room);
+          } catch (err) {
+            const detail = err instanceof Error ? err.message : String(err);
+            console.error(detail);
+            // "warning" rather than an error-flavoured intent: the toast is rendered by
+            // the consuming app, and "warning" is the only problem intent already in use
+            // here, so it is the one value known to be understood.
+            messenger.postMessage("SHOW_TOAST", {
+              message: detail,
+              intent: "warning",
+              timeout: 4000
+            });
+          }
         } break;
         case "obj":
           {

--- a/src/lib/registerHandlers.ts
+++ b/src/lib/registerHandlers.ts
@@ -363,9 +363,20 @@ export function registerMessageHandlers(
           case "dxf":
             {
               const result = await (await fetch(objectURL)).text();
-              const room = importHandlers.dxf(result);
-              emit("ADD_ROOM", room);
-              console.log(room);
+              try {
+                const room = importHandlers.dxf(result);
+                emit("ADD_ROOM", room);
+                console.log(room);
+              } catch (err) {
+                const detail = err instanceof Error ? err.message : String(err);
+                console.error(detail);
+                // See the matching handler in index.tsx for why this is "warning".
+                msg.postMessage("SHOW_TOAST", {
+                  message: detail,
+                  intent: "warning",
+                  timeout: 4000
+                });
+              }
             } break;
           case "obj":
             {


### PR DESCRIPTION
Two defects in the DXF import path, both surfaced by triaging [dxf-parser](https://github.com/gdsestimating/dxf-parser)'s 42 open issues against what CRAM actually calls.

CRAM's path is narrow — `entities.filter(x => x.type === "POLYLINE")`, then `faceA/B/C` into a polyface mesh — so most of that tracker is irrelevant. These two are not.

## 1. Polyface quads lost half their geometry

`dxf-parser` parses group code 74 into `vertex.faceD` and declares it on `IVertexEntity` (`src/entities/vertex.ts:67-68`), but the handler read only `faceA/faceB/faceC`:

```js
indices.push([vertex["faceA"]!, vertex["faceB"]!, vertex["faceC"]!].map(Math.abs).map(x=>x-1));
```

DXF polyface meshes encode **quads** with a non-zero faceD. CRAM emitted one triangle instead of two, so every quad face imported as a hole — and most CAD exporters emit quads freely, so this hit ordinary files.

Quads are now split into `[A,B,C]` and `[A,C,D]`. The existing global `indices.flat().reverse()` reverses a concatenation of contiguous triples, so it flips both triangles' winding consistently — the convention is unchanged.

The handler's hand-rolled `Vertex` interface also omitted `faceD`, which is what kept this invisible: the local type modelled three indices, so nothing suggested a fourth existed. Upstream ships the field (this is the practical cost of dxf-parser issue #96, "Types?").

## 2. Parse failures vanished silently

Three ways the parse could fail, none of them survivable:

- `dxf-parser` throws a bare scanner error on unrecognised group codes (upstream #102)
- it returns `null` for input it can't read at all
- a file with no ENTITIES section crashed on `.filter` of `undefined`

Both callers invoke `dxf()` from an un-caught `async` callback, so each of these became a **swallowed unhandled rejection** — no room, no error, no console output. A user importing an unsupported DXF saw literally nothing happen.

The parse is now guarded and the errors attributed (`Could not parse DXF file: …`), matching the `throw new Error` convention already used in `obj.ts`. Both call sites catch.

On the toast: it uses intent `"warning"` rather than an error-flavoured value. `SHOW_TOAST` is untyped and has no in-repo listener — the consuming app renders it — and `"warning"` is the only problem intent already used in this codebase, so it's the one value known to be understood. `"danger"` (Blueprint) and `"error"` (MUI) each risk being invalid under the other vocabulary. `console.error` carries the detail regardless.

## Testing

First tests for this path — `import-handlers/__tests__/` previously had only `obj.spec.ts` and `stl.spec.ts`. Fixtures are real DXF text built from group-code pairs and verified against the actual parser, not hand-waved.

**Six of the nine fail against the previous code:**

```
× splits a quad face into two triangles          expected length 18, got 9
× covers all four corners of a quad              Set{'1,1,0','1,0,0','0,0,0'} — fourth corner absent
× treats negative indices as visible-edge flags  expected length 18, got 9
× throws a descriptive error                     got 'Empty file'
× throws when there is no ENTITIES section       got 'Cannot read properties of undefined'
× names the file type in the message             'Empty file' does not match /DXF/
```

Those last three are the old behaviour exactly: an unattributable parser string, and a raw TypeError from filtering `undefined`.

Full suite: **94 files, 1874 tests, 0 failures.** `tsc --noEmit` clean on all touched files.

## Not addressed here

From the same triage, left for follow-ups:

- **Float32 precision** (upstream #77) — `makeBufferGeometry` does `new Float32Array(position)` on raw DXF coordinates. Site-coordinate files (UTM, state plane) will jitter or collapse. Needs a centroid offset stored on the Room.
- **Main-thread `parseSync`** (upstream #49) — large DXFs freeze the UI.
- **Scope gaps** — LINE, LWPOLYLINE, 3DFACE, and INSERT/blocks are still dropped. A DXF exported as 3DFACE meshes, which is common, imports as an empty room. It now at least fails loudly if the file is unparseable, but a parseable file with no POLYLINE entities is still silently empty.
- `package.json` pins `dxf-parser` at `^1.0.0-alpha.2`, an alpha range resolving to 1.1.2; should be `^1.1.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
