### PR TITLE
fix(dxf): recentre site-grid geometry to survive float32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "beam-trace": "github:10log/BeamTrace2D#master",
         "chroma-js": "^3.2.0",
         "d3": "^7.9.0",
-        "dxf-parser": "^1.0.0-alpha.2",
+        "dxf-parser": "^1.1.2",
         "fast-fuzzy": "^1.9.1",
         "file-saver": "^2.0.2",
         "flexlayout-react": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "beam-trace": "github:10log/BeamTrace2D#master",
     "chroma-js": "^3.2.0",
     "d3": "^7.9.0",
-    "dxf-parser": "^1.0.0-alpha.2",
+    "dxf-parser": "^1.1.2",
     "fast-fuzzy": "^1.9.1",
     "file-saver": "^2.0.2",
     "flexlayout-react": "^0.10.0",

--- a/src/import-handlers/__tests__/dxf.spec.ts
+++ b/src/import-handlers/__tests__/dxf.spec.ts
@@ -31,6 +31,17 @@ vi.mock('../../objects/room', () => ({
   default: vi.fn().mockImplementation(function (this: any, name: string, props: any) {
     this.name = name;
     this.surfaces = props.surfaces;
+    this.position = {
+      x: 0,
+      y: 0,
+      z: 0,
+      set(x: number, y: number, z: number) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+      },
+    };
+    this.updateMatrixWorld = vi.fn();
   }),
 }));
 
@@ -59,14 +70,21 @@ const faceRecord = (a: number, b: number, c: number, d?: number) => {
   return group(pairs);
 };
 
-const polyfaceDxf = (vertices: string[], faces: string[]) =>
-  group([[0, 'SECTION'], [2, 'ENTITIES']]) +
-  group([[0, 'POLYLINE'], [8, 'walls'], [66, 1], [70, 64], [71, vertices.length], [72, faces.length]]) +
+/** One POLYLINE polyface entity; each becomes its own Surface. */
+const polylineEntity = (vertices: string[], faces: string[], layer = 'walls') =>
+  group([[0, 'POLYLINE'], [8, layer], [66, 1], [70, 64], [71, vertices.length], [72, faces.length]]) +
   vertices.join('') +
   faces.join('') +
-  group([[0, 'SEQEND']]) +
+  group([[0, 'SEQEND']]);
+
+const entitiesDxf = (...entities: string[]) =>
+  group([[0, 'SECTION'], [2, 'ENTITIES']]) +
+  entities.join('') +
   group([[0, 'ENDSEC']]) +
   group([[0, 'EOF']]);
+
+const polyfaceDxf = (vertices: string[], faces: string[]) =>
+  entitiesDxf(polylineEntity(vertices, faces));
 
 const unitQuad = [meshVertex(0, 0, 0), meshVertex(1, 0, 0), meshVertex(1, 1, 0), meshVertex(0, 1, 0)];
 
@@ -137,6 +155,95 @@ describe('dxf import handler', () => {
       }
 
       expect(message).toMatch(/DXF/);
+    });
+  });
+
+  describe('site-grid coordinates', () => {
+    // A UTM easting/northing. float32 values are half a metre apart at this magnitude,
+    // so storing the vertices raw snaps separate walls onto each other.
+    const E = 500000;
+    const N = 4500000;
+
+    /** Four walls 0.2 m apart in y, drawn on a site grid. */
+    const spacedWalls = () => {
+      const ys = [0, 0.2, 0.4, 0.6];
+      const vertices = ys.flatMap((dy) => [
+        meshVertex(E, N + dy, 0),
+        meshVertex(E + 1, N + dy, 0),
+        meshVertex(E + 1, N + dy, 2),
+      ]);
+      const faces = ys.map((_, i) => faceRecord(i * 3 + 1, i * 3 + 2, i * 3 + 3));
+      return polyfaceDxf(vertices, faces);
+    };
+
+    it('keeps walls distinct that float32 would otherwise merge', () => {
+      dxf(spacedWalls());
+
+      const ys = new Set<number>();
+      for (const surface of createdSurfaces) {
+        for (let i = 1; i < surface.positions.length; i += 3) ys.add(surface.positions[i]);
+      }
+
+      // Stored raw, the four northings collapse onto two or three representable values.
+      expect(ys.size).toBe(4);
+    });
+
+    it('preserves the 0.2 m spacing between them', () => {
+      dxf(spacedWalls());
+
+      const ys = [...new Set(createdSurfaces.flatMap((s) =>
+        s.positions.filter((_, i) => i % 3 === 1)))].sort((a, b) => a - b);
+
+      for (let i = 1; i < ys.length; i++) {
+        expect(ys[i] - ys[i - 1]).toBeCloseTo(0.2, 4);
+      }
+    });
+
+    it('moves the discarded magnitude onto the room transform', () => {
+      const room: any = dxf(spacedWalls());
+
+      expect(room.position.x).toBeCloseTo(E + 0.5, 3);
+      expect(room.position.y).toBeCloseTo(N + 0.3, 3);
+    });
+
+    it('leaves the model where the file drew it', () => {
+      const room: any = dxf(spacedWalls());
+
+      // local vertex + room offset should reconstruct the original coordinate
+      const xs = createdSurfaces.flatMap((s) => s.positions.filter((_, i) => i % 3 === 0));
+      const worldXs = xs.map((x) => x + room.position.x);
+
+      expect(Math.min(...worldXs)).toBeCloseTo(E, 3);
+      expect(Math.max(...worldXs)).toBeCloseTo(E + 1, 3);
+    });
+
+    it('shares one offset across every surface so the model does not scatter', () => {
+      // Two separate POLYLINE entities 40 m apart on the site grid.
+      const triangleAt = (x: number, y: number) =>
+        polylineEntity(
+          [meshVertex(x, y, 0), meshVertex(x + 1, y, 0), meshVertex(x + 1, y, 2)],
+          [faceRecord(1, 2, 3)]
+        );
+
+      dxf(entitiesDxf(triangleAt(E, N), triangleAt(E + 40, N)));
+
+      expect(createdSurfaces).toHaveLength(2);
+
+      // A per-surface offset would drop both onto their own local origin and destroy the
+      // 40 m separation. One shared offset keeps them apart.
+      const firstX = createdSurfaces[0].positions[0];
+      const secondX = createdSurfaces[1].positions[0];
+
+      expect(Math.abs(secondX - firstX)).toBeCloseTo(40, 3);
+    });
+
+    it('does not recentre a file float32 already represents faithfully', () => {
+      const room: any = dxf(polyfaceDxf(unitQuad, [faceRecord(1, 2, 3, 4)]));
+
+      expect(room.position.x).toBe(0);
+      expect(room.position.y).toBe(0);
+      expect(room.position.z).toBe(0);
+      expect(createdSurfaces[0].positions).toContain(1); // untouched, not shifted to -0.5
     });
   });
 

--- a/src/import-handlers/dxf.ts
+++ b/src/import-handlers/dxf.ts
@@ -6,6 +6,52 @@ import Surface from '../objects/surface';
 import {useMaterial} from '../store/material-store';
 
 
+/**
+ * Largest positional error we are willing to bake into the geometry, in model units.
+ * A millimetre is far below anything acoustically meaningful — the shortest wavelength
+ * in the 8 kHz band is roughly 43 mm.
+ */
+const POSITION_TOLERANCE = 1e-3;
+
+/** Worst error introduced by storing these coordinates as float32. */
+const worstFloat32Error = (positions: number[]) => {
+  let worst = 0;
+  for (const value of positions) {
+    const error = Math.abs(Math.fround(value) - value);
+    if (error > worst) worst = error;
+  }
+  return worst;
+};
+
+/**
+ * Centre of the axis-aligned bounds, or null when float32 already represents the file
+ * faithfully.
+ *
+ * Vertex positions reach WebGL as float32, which carries about seven significant digits.
+ * DXF files drawn on a site grid — UTM, state plane — put coordinates in the millions,
+ * where consecutive float32 values are half a metre apart, so distinct walls collapse
+ * onto each other. Shifting the geometry to the origin and carrying the displacement on
+ * the Room's transform keeps the detail, because Object3D.position is float64.
+ */
+const recenteringOffset = (positions: number[]): [number, number, number] | null => {
+  if (positions.length === 0) return null;
+  if (worstFloat32Error(positions) <= POSITION_TOLERANCE) return null;
+
+  const min = [Infinity, Infinity, Infinity];
+  const max = [-Infinity, -Infinity, -Infinity];
+  for (let i = 0; i < positions.length; i += 3) {
+    for (let axis = 0; axis < 3; axis++) {
+      const value = positions[i + axis];
+      if (value < min[axis]) min[axis] = value;
+      if (value > max[axis]) max[axis] = value;
+    }
+  }
+  return [0, 1, 2].map((axis) => (min[axis] + max[axis]) / 2) as [number, number, number];
+};
+
+const applyOffset = (positions: number[], offset: [number, number, number] | null) =>
+  offset ? positions.map((value, i) => value - offset[i % 3]) : positions;
+
 const makeBufferGeometry = (position: number[], _normals?: number[], _texCoords?: number[]) => {
   const buffer = new BufferGeometry();
   buffer.setAttribute("position", new BufferAttribute(new Float32Array(position), 3, false));
@@ -37,14 +83,9 @@ export function dxf(data: string){
     throw new Error("Could not read DXF file: no ENTITIES section was found.");
   }
 
-  const layerMap = new Map<string, Container>();
-  parsed.entities.filter(x=>x.type==="POLYLINE").forEach((polyline,i)=>{
-    const _material = polyline.materialObjectHandle;
-    const layer = polyline.layer;
-    if(!layerMap.has(layer)){
-      layerMap.set(layer, new Container(layer));
-    }
-
+  // Decode every polyface mesh before building any geometry: the recentring offset has to
+  // be shared by all of them, since a per-surface offset would scatter the model.
+  const meshes = parsed.entities.filter(x=>x.type==="POLYLINE").map(polyline=>{
     const vertices = [] as number[][];
     const indices = [] as number[][];
     polyline.vertices.forEach(vertex=>{
@@ -65,11 +106,22 @@ export function dxf(data: string){
       }
     });
 
-    let vertices_i = (indices.flat().reverse() as number[]).map(index=>vertices[index]).flat() as number[];
-    const geometry = makeBufferGeometry((vertices_i));
-    geometry.computeVertexNormals(); 
-    geometry.setAttribute("normals", geometry.getAttribute("normal")); 
-    
+    const positions = (indices.flat().reverse() as number[]).map(index=>vertices[index]).flat() as number[];
+    return { layer: polyline.layer, positions };
+  });
+
+  const offset = recenteringOffset(meshes.flatMap(mesh=>mesh.positions));
+
+  const layerMap = new Map<string, Container>();
+  meshes.forEach(({layer, positions}, i)=>{
+    if(!layerMap.has(layer)){
+      layerMap.set(layer, new Container(layer));
+    }
+
+    const geometry = makeBufferGeometry(applyOffset(positions, offset));
+    geometry.computeVertexNormals();
+    geometry.setAttribute("normals", geometry.getAttribute("normal"));
+
     const acousticMaterial = defaultMaterial;
     const surface = new Surface(`untitled-${i}`, {
       acousticMaterial,
@@ -81,6 +133,17 @@ export function dxf(data: string){
   const room = new Room("new room", {
     surfaces: [...layerMap.values()]
   });
+
+  if (offset) {
+    // Put the model back where the file drew it. Object3D.position is float64, so the
+    // magnitude that float32 could not hold is preserved here rather than in the vertices.
+    room.position.set(offset[0], offset[1], offset[2]);
+    room.updateMatrixWorld(true);
+    console.info(
+      `DXF coordinates exceed float32 precision; geometry recentred by ` +
+      `[${offset.map(n=>n.toFixed(3)).join(", ")}] and the offset moved onto the room transform.`
+    );
+  }
 
   return room;
 


### PR DESCRIPTION
> **Stacked on #92** — targets `fix/dxf-quad-faces-and-parse-guard`, since it restructures the same function. Merge #92 first and this retargets to `varese-dev` cleanly.

Closes the precision gap flagged in #92's follow-up list (upstream [dxf-parser#77](https://github.com/gdsestimating/dxf-parser/issues/77)), plus the dependency-range correction from the same triage.

## The problem

Vertex positions reach WebGL as float32, which carries about seven significant digits. DXF files drawn on a site grid — UTM, state plane — put coordinates in the millions, where consecutive float32 values are **half a metre apart**. `makeBufferGeometry` wrote those coordinates straight into a `Float32Array`.

Four walls 0.2 m apart at northing 4,500,000, stored raw:

```
true y        stored as f32     delta from first
4500000.0     4500000.0000       0.0000
4500000.2     4500000.0000       0.0000   <- merged with the first
4500000.4     4500000.5000       0.5000
4500000.6     4500000.5000       0.5000   <- merged with the third
```

Four distinct walls become two positions. Half a metre of error is meaningless geometry for an acoustics solve — the 8 kHz band has a wavelength of roughly 43 mm.

## The fix

Shift the geometry to the origin and carry the displacement on the Room's transform. `Object3D.position` is float64, so it holds exactly the magnitude float32 could not — the standard floating-origin treatment, and what the upstream maintainer recommends in #77.

Two details that matter:

- **One offset for the whole file.** A per-surface offset would drop every surface onto its own local origin and destroy their relative placement. That's why geometry construction now happens in a second pass — the offset can't be known until every polyface mesh is decoded. There's a test asserting two entities 40 m apart stay 40 m apart.
- **Only when it's actually needed.** The trigger is measured, not guessed: `worstFloat32Error` computes the real round-trip error of the file's own coordinates and recentres only if it exceeds 1 mm. Files already near the origin keep an identity transform and are byte-for-byte untouched.

## Trade-off worth reviewing

This trades one known inconsistency for another, in the large-coordinate case only.

Some consumers read surface geometry through `matrixWorld` (`beam-trace:650`, `radiance/patch:55`, `gpu-bvh:86`, `image-source:1047`); others read raw local positions (`surface.ts:304` building `_triangles`, `2d-fdtd:401`). A non-zero room transform makes those two groups disagree.

That disagreement is **pre-existing** — any moved, restored, or transform-controlled object already triggers it — and it now applies only to files that today import as corrupted geometry. So this is strictly better than the status quo rather than a new hazard. But it is a real inconsistency and worth knowing about; the durable fix is making the raw-local readers honour `matrixWorld`, which is a separate change.

If you'd rather not introduce a non-zero room transform at all, the alternative is recentring to the origin and discarding the offset entirely. That keeps every transform identity, at the cost of losing cross-import alignment between files that share a site grid. Say the word and I'll switch it.

## Also here: dependency range correction

`package.json` declared `dxf-parser: "^1.0.0-alpha.2"`. A prerelease range invites prerelease resolutions and reads as though the project depends on unreleased code. npm was already resolving **1.1.2**, so this corrects only the declared range — the lockfile diff is a single line and no package moves:

```diff
-        "dxf-parser": "^1.0.0-alpha.2",
+        "dxf-parser": "^1.1.2",
```

## Testing

Six new cases. **Three fail against the pre-fix code**, with the collapse reproduced exactly:

```
× keeps walls distinct that float32 would otherwise merge   expected 2 to be 4
× preserves the 0.2 m spacing between them                  expected 0.5 to be close to 0.2
× moves the discarded magnitude onto the room transform     expected +0 to be close to 500000.5
```

The other three pin properties that must not regress: the model stays where the file drew it (local vertex + room offset reconstructs the original coordinate), one shared offset across surfaces, and no recentring for ordinary files.

Full suite: **94 files, 1880 tests, 0 failures**, re-run after the dependency change. `tsc --noEmit` clean.

## Still outstanding from the dxf-parser triage

- Main-thread `parseSync` on large files (upstream #49)
- Entity scope: LINE, LWPOLYLINE, 3DFACE, INSERT/blocks still dropped; a parseable file with no POLYLINE entities still imports as a silently empty room

🤖 Generated with [Claude Code](https://claude.com/claude-code)
