### PR TITLE
perf(dxf): parse off the main thread

### DIFF
--- a/src/import-handlers/__tests__/dxf.spec.ts
+++ b/src/import-handlers/__tests__/dxf.spec.ts
@@ -1,4 +1,4 @@
-import { dxf } from '../dxf';
+import { dxf, dxfAsync } from '../dxf';
 
 vi.mock('three', async () => await vi.importActual('../../__mocks__/three'));
 
@@ -244,6 +244,124 @@ describe('dxf import handler', () => {
       expect(room.position.y).toBe(0);
       expect(room.position.z).toBe(0);
       expect(createdSurfaces[0].positions).toContain(1); // untouched, not shifted to -0.5
+    });
+  });
+
+  describe('dxfAsync', () => {
+    /** Stands in for a real Worker: jsdom has none, and we want to drive the responses. */
+    class FakeWorker {
+      static last: FakeWorker | null = null;
+      listeners: Record<string, Array<(event: any) => void>> = {};
+      posted: any[] = [];
+      terminate = vi.fn();
+
+      constructor(public url: unknown, public options?: unknown) {
+        FakeWorker.last = this;
+      }
+      addEventListener(type: string, fn: (event: any) => void) {
+        (this.listeners[type] ||= []).push(fn);
+      }
+      postMessage(message: any) {
+        this.posted.push(message);
+      }
+      emit(type: string, event: any) {
+        (this.listeners[type] || []).forEach((fn) => fn(event));
+      }
+    }
+
+    const withFakeWorker = async (run: () => Promise<any>) => {
+      (globalThis as any).Worker = FakeWorker;
+      try {
+        return await run();
+      } finally {
+        delete (globalThis as any).Worker;
+        FakeWorker.last = null;
+      }
+    };
+
+    const quad = () => polyfaceDxf(unitQuad, [faceRecord(1, 2, 3, 4)]);
+
+    it('falls back to parsing in place when the environment has no Worker', async () => {
+      expect(typeof (globalThis as any).Worker).toBe('undefined');
+
+      const room: any = await dxfAsync(quad());
+
+      expect(room.surfaces).toHaveLength(1);
+      expect(createdSurfaces[0].positions).toHaveLength(18);
+    });
+
+    it('hands the file to the worker rather than parsing on this thread', async () => {
+      await withFakeWorker(async () => {
+        const pending = dxfAsync(quad());
+        const worker = FakeWorker.last!;
+
+        expect(worker.posted).toEqual([{ data: quad() }]);
+
+        // Positions the parser could never produce from that input, so a pass proves the
+        // room was built from the worker's reply and not re-parsed here.
+        worker.emit('message', {
+          data: {
+            ok: true,
+            meshes: [{ layer: 'from-worker', positions: new Float32Array([7, 7, 7, 8, 8, 8, 9, 9, 9]) }],
+            offset: null,
+          },
+        });
+
+        const room: any = await pending;
+        expect(room.surfaces).toHaveLength(1);
+        expect(createdSurfaces[0].positions).toEqual([7, 7, 7, 8, 8, 8, 9, 9, 9]);
+      });
+    });
+
+    it('applies the offset the worker reports', async () => {
+      await withFakeWorker(async () => {
+        const pending = dxfAsync(quad());
+        FakeWorker.last!.emit('message', {
+          data: {
+            ok: true,
+            meshes: [{ layer: 'walls', positions: new Float32Array([0, 0, 0, 1, 0, 0, 1, 1, 0]) }],
+            offset: [500000, 4500000, 0],
+          },
+        });
+
+        const room: any = await pending;
+        expect(room.position.x).toBe(500000);
+        expect(room.position.y).toBe(4500000);
+      });
+    });
+
+    it('rejects with the parser message when the worker reports failure', async () => {
+      await withFakeWorker(async () => {
+        const pending = dxfAsync('not a dxf');
+        FakeWorker.last!.emit('message', {
+          data: { ok: false, message: 'Could not parse DXF file: Empty file' },
+        });
+
+        await expect(pending).rejects.toThrow(/Could not parse DXF file/);
+      });
+    });
+
+    it('parses in place when the worker itself fails to run', async () => {
+      await withFakeWorker(async () => {
+        const pending = dxfAsync(quad());
+        FakeWorker.last!.emit('error', { message: 'worker failed to start' });
+
+        // A broken worker says nothing about the file, so the import should still succeed.
+        const room: any = await pending;
+        expect(room.surfaces).toHaveLength(1);
+        expect(createdSurfaces[0].positions).toHaveLength(18);
+      });
+    });
+
+    it('terminates the worker once it has replied', async () => {
+      await withFakeWorker(async () => {
+        const pending = dxfAsync(quad());
+        const worker = FakeWorker.last!;
+        worker.emit('message', { data: { ok: true, meshes: [], offset: null } });
+        await pending;
+
+        expect(worker.terminate).toHaveBeenCalled();
+      });
     });
   });
 

--- a/src/import-handlers/dxf-decode.ts
+++ b/src/import-handlers/dxf-decode.ts
@@ -1,0 +1,131 @@
+import DxfParser from 'dxf-parser';
+import type { Dxf } from './dxf';
+
+/**
+ * Parsing and geometry decoding for DXF, kept free of THREE, the stores, and the DOM so
+ * it can run inside a worker as well as on the main thread. Everything that builds scene
+ * objects lives in ./dxf.
+ */
+
+/** One polyface mesh, flattened to triangle vertices. */
+export interface DecodedMesh {
+  layer: string;
+  positions: number[];
+}
+
+export interface DecodedDxf {
+  meshes: DecodedMesh[];
+  /** Displacement removed from the positions, to be carried on the Room transform. */
+  offset: [number, number, number] | null;
+}
+
+/**
+ * Largest positional error we are willing to bake into the geometry, in model units.
+ * A millimetre is far below anything acoustically meaningful — the shortest wavelength
+ * in the 8 kHz band is roughly 43 mm.
+ */
+const POSITION_TOLERANCE = 1e-3;
+
+/** Worst error introduced by storing these coordinates as float32. */
+export const worstFloat32Error = (positions: number[]) => {
+  let worst = 0;
+  for (const value of positions) {
+    const error = Math.abs(Math.fround(value) - value);
+    if (error > worst) worst = error;
+  }
+  return worst;
+};
+
+/**
+ * Centre of the axis-aligned bounds, or null when float32 already represents the file
+ * faithfully.
+ *
+ * Vertex positions reach WebGL as float32, which carries about seven significant digits.
+ * DXF files drawn on a site grid — UTM, state plane — put coordinates in the millions,
+ * where consecutive float32 values are half a metre apart, so distinct walls collapse
+ * onto each other. Shifting the geometry to the origin and carrying the displacement on
+ * the Room's transform keeps the detail, because Object3D.position is float64.
+ */
+export const recenteringOffset = (positions: number[]): [number, number, number] | null => {
+  if (positions.length === 0) return null;
+  if (worstFloat32Error(positions) <= POSITION_TOLERANCE) return null;
+
+  const min = [Infinity, Infinity, Infinity];
+  const max = [-Infinity, -Infinity, -Infinity];
+  for (let i = 0; i < positions.length; i += 3) {
+    for (let axis = 0; axis < 3; axis++) {
+      const value = positions[i + axis];
+      if (value < min[axis]) min[axis] = value;
+      if (value > max[axis]) max[axis] = value;
+    }
+  }
+  return [0, 1, 2].map((axis) => (min[axis] + max[axis]) / 2) as [number, number, number];
+};
+
+export const applyOffset = (positions: number[], offset: [number, number, number] | null) =>
+  offset ? positions.map((value, i) => value - offset[i % 3]) : positions;
+
+/**
+ * Parse a DXF document and flatten its polyface meshes into triangle vertices, recentred
+ * if the file's coordinates outrun float32.
+ *
+ * Throws a descriptive Error for input that cannot be read: dxf-parser raises a bare
+ * scanner error on any group code it doesn't recognise and returns null for input it
+ * can't make sense of at all, neither of which says anything about the file.
+ */
+export function decodeDxf(data: string): DecodedDxf {
+  let parsedData: unknown;
+  try {
+    parsedData = new DxfParser().parseSync(data);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`Could not parse DXF file: ${detail}`);
+  }
+  if (!parsedData) {
+    throw new Error("Could not parse DXF file: the parser returned no data.");
+  }
+
+  const parsed = parsedData as Dxf;
+  if (!Array.isArray(parsed.entities)) {
+    throw new Error("Could not read DXF file: no ENTITIES section was found.");
+  }
+
+  // Decode every polyface mesh before computing the offset: it has to be shared by all of
+  // them, since a per-surface offset would collapse each onto its own origin and scatter
+  // the model.
+  const meshes = parsed.entities.filter(x => x.type === "POLYLINE").map(polyline => {
+    const vertices = [] as number[][];
+    const indices = [] as number[][];
+    polyline.vertices.forEach(vertex => {
+      if (vertex["faceA"]) {
+        // Face indices are 1-based, and negative when the edge leading away from that
+        // vertex is invisible — so take the magnitude before converting to 0-based.
+        const [a, b, c, d] = [vertex.faceA, vertex.faceB, vertex.faceC, vertex.faceD]
+          .map(index => (index ? Math.abs(index) - 1 : -1));
+        indices.push([a, b, c]);
+        // A polyface quad carries a fourth index (group code 74); triangles leave it
+        // absent, zero, or repeating the third vertex. Without this the second half of
+        // every quad was dropped, leaving a hole.
+        if (d >= 0 && d !== c) {
+          indices.push([a, c, d]);
+        }
+      } else {
+        vertices.push([vertex.x, vertex.y, vertex.z!]);
+      }
+    });
+
+    const positions = (indices.flat().reverse() as number[])
+      .map(index => vertices[index]).flat() as number[];
+    return { layer: polyline.layer, positions };
+  });
+
+  const offset = recenteringOffset(meshes.flatMap(mesh => mesh.positions));
+
+  return {
+    meshes: meshes.map(({ layer, positions }) => ({
+      layer,
+      positions: applyOffset(positions, offset),
+    })),
+    offset,
+  };
+}

--- a/src/import-handlers/dxf.ts
+++ b/src/import-handlers/dxf.ts
@@ -1,58 +1,13 @@
-import DxfParser from 'dxf-parser';
 import {BufferGeometry, BufferAttribute} from 'three';
 import Container from '../objects/container';
 import Room from '../objects/room';
 import Surface from '../objects/surface';
 import {useMaterial} from '../store/material-store';
+import { decodeDxf } from './dxf-decode';
+import type { DecodedDxf } from './dxf-decode';
+import type { DxfWorkerResponse } from './dxf.worker';
 
-
-/**
- * Largest positional error we are willing to bake into the geometry, in model units.
- * A millimetre is far below anything acoustically meaningful — the shortest wavelength
- * in the 8 kHz band is roughly 43 mm.
- */
-const POSITION_TOLERANCE = 1e-3;
-
-/** Worst error introduced by storing these coordinates as float32. */
-const worstFloat32Error = (positions: number[]) => {
-  let worst = 0;
-  for (const value of positions) {
-    const error = Math.abs(Math.fround(value) - value);
-    if (error > worst) worst = error;
-  }
-  return worst;
-};
-
-/**
- * Centre of the axis-aligned bounds, or null when float32 already represents the file
- * faithfully.
- *
- * Vertex positions reach WebGL as float32, which carries about seven significant digits.
- * DXF files drawn on a site grid — UTM, state plane — put coordinates in the millions,
- * where consecutive float32 values are half a metre apart, so distinct walls collapse
- * onto each other. Shifting the geometry to the origin and carrying the displacement on
- * the Room's transform keeps the detail, because Object3D.position is float64.
- */
-const recenteringOffset = (positions: number[]): [number, number, number] | null => {
-  if (positions.length === 0) return null;
-  if (worstFloat32Error(positions) <= POSITION_TOLERANCE) return null;
-
-  const min = [Infinity, Infinity, Infinity];
-  const max = [-Infinity, -Infinity, -Infinity];
-  for (let i = 0; i < positions.length; i += 3) {
-    for (let axis = 0; axis < 3; axis++) {
-      const value = positions[i + axis];
-      if (value < min[axis]) min[axis] = value;
-      if (value > max[axis]) max[axis] = value;
-    }
-  }
-  return [0, 1, 2].map((axis) => (min[axis] + max[axis]) / 2) as [number, number, number];
-};
-
-const applyOffset = (positions: number[], offset: [number, number, number] | null) =>
-  offset ? positions.map((value, i) => value - offset[i % 3]) : positions;
-
-const makeBufferGeometry = (position: number[], _normals?: number[], _texCoords?: number[]) => {
+const makeBufferGeometry = (position: ArrayLike<number>, _normals?: number[], _texCoords?: number[]) => {
   const buffer = new BufferGeometry();
   buffer.setAttribute("position", new BufferAttribute(new Float32Array(position), 3, false));
   if(_normals) buffer.setAttribute("normals", new BufferAttribute(new Float32Array(_normals), 3, false));
@@ -60,57 +15,10 @@ const makeBufferGeometry = (position: number[], _normals?: number[], _texCoords?
   return buffer;
 }
 
-export function dxf(data: string){
+/** Assemble scene objects from decoded geometry. Must run on the main thread. */
+function buildRoom(decoded: { meshes: Array<{ layer: string; positions: ArrayLike<number> }>; offset: DecodedDxf["offset"] }) {
   const defaultMaterial = [...useMaterial.getState().materials.values()][0];
-
-  // dxf-parser throws a bare scanner error on any group code it doesn't recognise, and
-  // returns null for input it can't make sense of at all. Both callers invoke this from an
-  // async handler with no catch, so an unguarded failure surfaces as nothing whatsoever —
-  // no room, no message. Attribute the failure instead.
-  let parsedData: unknown;
-  try {
-    parsedData = new DxfParser().parseSync(data);
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    throw new Error(`Could not parse DXF file: ${detail}`);
-  }
-  if (!parsedData) {
-    throw new Error("Could not parse DXF file: the parser returned no data.");
-  }
-
-  const parsed = parsedData as Dxf;
-  if (!Array.isArray(parsed.entities)) {
-    throw new Error("Could not read DXF file: no ENTITIES section was found.");
-  }
-
-  // Decode every polyface mesh before building any geometry: the recentring offset has to
-  // be shared by all of them, since a per-surface offset would scatter the model.
-  const meshes = parsed.entities.filter(x=>x.type==="POLYLINE").map(polyline=>{
-    const vertices = [] as number[][];
-    const indices = [] as number[][];
-    polyline.vertices.forEach(vertex=>{
-      if(vertex["faceA"]){
-        // Face indices are 1-based, and negative when the edge leading away from that
-        // vertex is invisible — so take the magnitude before converting to 0-based.
-        const [a, b, c, d] = [vertex.faceA, vertex.faceB, vertex.faceC, vertex.faceD]
-          .map(index => (index ? Math.abs(index) - 1 : -1));
-        indices.push([a, b, c]);
-        // A polyface quad carries a fourth index (group code 74); triangles leave it
-        // absent, zero, or repeating the third vertex. Without this the second half of
-        // every quad was dropped, leaving a hole.
-        if (d >= 0 && d !== c) {
-          indices.push([a, c, d]);
-        }
-      } else {
-        vertices.push([vertex.x,vertex.y,vertex.z!]);
-      }
-    });
-
-    const positions = (indices.flat().reverse() as number[]).map(index=>vertices[index]).flat() as number[];
-    return { layer: polyline.layer, positions };
-  });
-
-  const offset = recenteringOffset(meshes.flatMap(mesh=>mesh.positions));
+  const { meshes, offset } = decoded;
 
   const layerMap = new Map<string, Container>();
   meshes.forEach(({layer, positions}, i)=>{
@@ -118,7 +26,7 @@ export function dxf(data: string){
       layerMap.set(layer, new Container(layer));
     }
 
-    const geometry = makeBufferGeometry(applyOffset(positions, offset));
+    const geometry = makeBufferGeometry(positions);
     geometry.computeVertexNormals();
     geometry.setAttribute("normals", geometry.getAttribute("normal"));
 
@@ -146,7 +54,64 @@ export function dxf(data: string){
   }
 
   return room;
+}
 
+/**
+ * Synchronous import. Parsing a large drawing blocks the thread it runs on, so prefer
+ * {@link dxfAsync} from anything the user is looking at; this remains for callers that
+ * cannot await, and backs the fallback path when workers are unavailable.
+ */
+export function dxf(data: string){
+  return buildRoom(decodeDxf(data));
+}
+
+/**
+ * Import off the main thread.
+ *
+ * Whole-file DXF parsing is the expensive part of the import and used to run
+ * synchronously on the UI thread, freezing the app for its duration on any large
+ * drawing. Only the parse and geometry decode move to the worker — scene objects need
+ * THREE and the renderer, so the Room is still assembled here.
+ *
+ * Falls back to parsing in place when the environment has no Worker, or when the worker
+ * cannot be started: a frozen tab beats a failed import.
+ */
+export function dxfAsync(data: string): Promise<ReturnType<typeof buildRoom>> {
+  if (typeof Worker === "undefined") {
+    return Promise.resolve(dxf(data));
+  }
+
+  let worker: Worker;
+  try {
+    worker = new Worker(new URL('./dxf.worker.ts', import.meta.url), { type: 'module' });
+  } catch {
+    return Promise.resolve(dxf(data));
+  }
+
+  return new Promise((resolve, reject) => {
+    worker.addEventListener("message", (event: MessageEvent<DxfWorkerResponse>) => {
+      worker.terminate();
+      const response = event.data;
+      if (!response.ok) {
+        reject(new Error(response.message));
+        return;
+      }
+      resolve(buildRoom({ meshes: response.meshes, offset: response.offset }));
+    });
+
+    worker.addEventListener("error", (event) => {
+      worker.terminate();
+      // The worker failed to start or threw outside the handler — the file itself may be
+      // perfectly good, so parse it here rather than failing the import.
+      try {
+        resolve(dxf(data));
+      } catch (err) {
+        reject(err instanceof Error ? err : new Error(String(event.message)));
+      }
+    });
+
+    worker.postMessage({ data });
+  });
 }
 
 export interface Dxf {

--- a/src/import-handlers/dxf.worker.ts
+++ b/src/import-handlers/dxf.worker.ts
@@ -1,0 +1,39 @@
+import { decodeDxf } from './dxf-decode';
+
+/**
+ * Parses DXF off the main thread. Whole-file parsing is the expensive part of a DXF
+ * import and it used to run synchronously on the UI thread, freezing the app for the
+ * duration on any large drawing.
+ *
+ * Scene objects cannot be built here — they need THREE and the renderer — so the worker
+ * returns flattened triangle vertices and the caller assembles the Room.
+ */
+
+const ctx: Worker = self as any;
+
+export {};
+
+export type DxfWorkerRequest = { data: string };
+
+export type DxfWorkerResponse =
+  | { ok: true; meshes: Array<{ layer: string; positions: Float32Array }>; offset: [number, number, number] | null }
+  | { ok: false; message: string };
+
+ctx.addEventListener("message", (event: MessageEvent<DxfWorkerRequest>) => {
+  try {
+    const { meshes, offset } = decodeDxf(event.data.data);
+
+    // Positions are already recentred, so float32 holds them without loss — and the
+    // buffers can then be transferred rather than copied.
+    const payload = meshes.map(({ layer, positions }) => ({
+      layer,
+      positions: new Float32Array(positions),
+    }));
+
+    const response: DxfWorkerResponse = { ok: true, meshes: payload, offset };
+    ctx.postMessage(response, payload.map(mesh => mesh.positions.buffer));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    ctx.postMessage({ ok: false, message } satisfies DxfWorkerResponse);
+  }
+});

--- a/src/import-handlers/index.ts
+++ b/src/import-handlers/index.ts
@@ -139,7 +139,7 @@ export function dae(data: string) {
   return res;
 }
 
-export {dxf} from './dxf';
+export {dxf, dxfAsync} from './dxf';
 
 export function gltf(data: ArrayBuffer): Promise<Model[]> {
   return new Promise((resolve, reject) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -475,7 +475,7 @@ messenger.addMessageHandler("IMPORT_FILE", (acc, ...args) => {
         {
           const result = await (await fetch(objectURL)).text();
           try {
-            const room = importHandlers.dxf(result);
+            const room = await importHandlers.dxfAsync(result);
             emit("ADD_ROOM", room);
             console.log(room);
           } catch (err) {

--- a/src/lib/registerHandlers.ts
+++ b/src/lib/registerHandlers.ts
@@ -364,7 +364,7 @@ export function registerMessageHandlers(
             {
               const result = await (await fetch(objectURL)).text();
               try {
-                const room = importHandlers.dxf(result);
+                const room = await importHandlers.dxfAsync(result);
                 emit("ADD_ROOM", room);
                 console.log(room);
               } catch (err) {


### PR DESCRIPTION
> **Stacked on #93** (which is stacked on #92). Each retargets automatically as the one below merges.

Closes the last item from the dxf-parser triage: upstream [#49](https://github.com/gdsestimating/dxf-parser/issues/49), which will not be fixed there.

## The problem

`new DxfParser().parseSync(data)` ran on the UI thread. Whole-file parsing is the expensive part of a DXF import, so any large drawing froze the app outright for its duration.

## The split

Scene objects can't be built in a worker — they need THREE and the renderer. So the boundary is drawn at the data:

- **Worker**: parse + decode polyface meshes + compute the recentring offset
- **Main thread**: assemble `BufferGeometry`, `Surface`, `Container`, `Room`

Positions cross as `Float32Array`. That's lossless here precisely because #93 already recentred them, and it lets the buffers be **transferred rather than copied**.

## Shape of the change

`dxf-decode.ts` (new) holds the parse and decode, free of THREE, the stores, and the DOM so it runs in either context. `dxf.ts` keeps `buildRoom` and exposes two entry points:

| | |
|---|---|
| `dxf(data)` | unchanged synchronous import; still the fallback |
| `dxfAsync(data)` | worker-backed; now used by both `IMPORT_FILE` handlers |

Both callers already sat inside `async` handlers, so they only needed an `await`.

**Fallback is deliberate and threefold** — no `Worker` in the environment, worker construction throws, or the worker emits `error`. In every case it parses in place. A broken worker says nothing about the file, so a frozen tab beats a failed import. Only an explicit `{ok: false}` from the worker — a genuine parse failure — rejects.

The worker follows the convention already in this repo (`audio-engine/filter.worker.ts`): `new Worker(new URL('./dxf.worker.ts', import.meta.url), { type: 'module' })`.

## Verification

A worker adds a bundling requirement, so I ran the real library build rather than assuming. `npm run build:lib` succeeds, `vite:worker-import-meta-url` runs, and the chunk is emitted beside the existing one:

```
dist/assets/dxf.worker-CgW00ASv.js      <- new
dist/assets/filter.worker-B2fYKvk6.js
```

Confirmed the decode logic is actually inside that chunk, and the sync fallback is still present in `dist/index.js`. Generated artifacts (`dist/`, the jscad bundle) were restored afterwards, so this commit is source only.

Six new tests. jsdom has no `Worker`, so the fallback path is exercised for real, and a stub Worker drives the plumbing:

- falls back to in-place parsing when there is no `Worker`
- hands the file to the worker rather than parsing here — asserted with positions the parser *could not* produce from the input, so a pass proves the reply was used
- applies the offset the worker reports
- rejects with the parser's message on `{ok: false}`
- parses in place when the worker itself fails to run
- terminates the worker once it has replied

All 21 pre-existing DXF tests pass unchanged, which is the evidence that extracting `dxf-decode.ts` was behaviour-preserving.

Full suite: **94 files, 1886 tests, 0 failures.** `tsc --noEmit` clean.

## Note on what this does not do

Parsing no longer blocks, but it is still whole-file — upstream #49 also asks for *streaming*, which `dxf-parser` does not support. A very large drawing now keeps the UI responsive while it parses, rather than parsing incrementally. Streaming would mean moving to a different parser (`dxf-json`), which I would not do for this alone.

The entity-coverage gap also remains: LINE, LWPOLYLINE, 3DFACE, and INSERT/blocks are still dropped, so a parseable DXF with no POLYLINE entities imports as a silently empty room. That needs an entity-count check and is a behaviour change rather than a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
