### PR TITLE
feat(dxf): import 3DFACE entities and explain empty imports

### DIFF
--- a/src/import-handlers/__tests__/dxf.spec.ts
+++ b/src/import-handlers/__tests__/dxf.spec.ts
@@ -247,6 +247,97 @@ describe('dxf import handler', () => {
     });
   });
 
+  describe('3DFACE', () => {
+    /** A 3DFACE entity; corner n uses group codes 10+n / 20+n / 30+n. */
+    const face3d = (
+      corners: Array<[number, number, number]>,
+      layer = 'walls',
+      trailing: Array<[number, string | number]> = []
+    ) => {
+      const codes: Array<[number, string | number]> = [[0, '3DFACE'], [8, layer]];
+      corners.forEach(([x, y, z], i) => codes.push([10 + i, x], [20 + i, y], [30 + i, z]));
+      return group(codes.concat(trailing));
+    };
+
+    const triangle: Array<[number, number, number]> = [[0, 0, 0], [1, 0, 0], [1, 1, 0]];
+    const quad: Array<[number, number, number]> = [...triangle, [0, 1, 0]];
+
+    it('imports a triangular face', () => {
+      dxf(entitiesDxf(face3d(triangle)));
+
+      expect(createdSurfaces).toHaveLength(1);
+      expect(createdSurfaces[0].positions).toHaveLength(9);
+    });
+
+    it('splits a quad face into two triangles', () => {
+      dxf(entitiesDxf(face3d(quad)));
+
+      expect(createdSurfaces[0].positions).toHaveLength(18);
+    });
+
+    it('discards the empty trailing vertex the parser appends', () => {
+      // dxf-parser pads the vertex list with {}; taken at face value it becomes a NaN
+      // corner and poisons the geometry.
+      dxf(entitiesDxf(face3d(triangle)));
+
+      expect(createdSurfaces[0].positions.every((n) => Number.isFinite(n))).toBe(true);
+    });
+
+    it('merges faces on the same layer into one surface', () => {
+      // One Surface per face would leave thousands of one-triangle surfaces that no
+      // material could sensibly be assigned to.
+      dxf(entitiesDxf(face3d(triangle), face3d([[2, 0, 0], [3, 0, 0], [3, 1, 0]])));
+
+      expect(createdSurfaces).toHaveLength(1);
+      expect(createdSurfaces[0].positions).toHaveLength(18);
+    });
+
+    it('keeps separate layers as separate surfaces', () => {
+      dxf(entitiesDxf(face3d(triangle, 'walls'), face3d(triangle, 'ceiling')));
+
+      expect(createdSurfaces).toHaveLength(2);
+    });
+
+    it('imports alongside polyface meshes', () => {
+      dxf(entitiesDxf(polylineEntity(unitQuad, [faceRecord(1, 2, 3, 4)]), face3d(triangle, 'ceiling')));
+
+      expect(createdSurfaces).toHaveLength(2);
+    });
+
+    // Known upstream limitation: dxf-parser drops the fourth vertex of a 3DFACE when a
+    // non-vertex group code follows it, which is what Revit exports look like
+    // (gdsestimating/dxf-parser#112). The data is gone before we see it, so a quad
+    // arrives as a triangle. This test pins that so it stays visible — if it starts
+    // failing, upstream has fixed the bug and this can go.
+    it('loses the fourth corner of a quad carrying trailing xdata (upstream #112)', () => {
+      dxf(entitiesDxf(face3d(quad, 'walls', [[1001, 'REVIT'], [1000, 'payload']])));
+
+      expect(createdSurfaces[0].positions).toHaveLength(9); // would be 18 if parsed fully
+    });
+  });
+
+  describe('files with nothing importable', () => {
+    it('names the entity types it found instead of importing an empty room', () => {
+      const linesOnly = entitiesDxf(
+        group([[0, 'LINE'], [8, 'plan'], [10, 0], [20, 0], [30, 0], [11, 1], [21, 1], [31, 0]])
+      );
+
+      expect(() => dxf(linesOnly)).toThrow(/No importable geometry.*LINE/s);
+    });
+
+    it('says what the importer does read', () => {
+      const linesOnly = entitiesDxf(
+        group([[0, 'LINE'], [8, 'plan'], [10, 0], [20, 0], [30, 0], [11, 1], [21, 1], [31, 0]])
+      );
+
+      expect(() => dxf(linesOnly)).toThrow(/POLYLINE and 3DFACE/);
+    });
+
+    it('reports an entities section with nothing in it', () => {
+      expect(() => dxf(entitiesDxf())).toThrow(/no entities to import/);
+    });
+  });
+
   describe('dxfAsync', () => {
     /** Stands in for a real Worker: jsdom has none, and we want to drive the responses. */
     class FakeWorker {

--- a/src/import-handlers/dxf-decode.ts
+++ b/src/import-handlers/dxf-decode.ts
@@ -65,9 +65,46 @@ export const recenteringOffset = (positions: number[]): [number, number, number]
 export const applyOffset = (positions: number[], offset: [number, number, number] | null) =>
   offset ? positions.map((value, i) => value - offset[i % 3]) : positions;
 
+/** Entity types this importer turns into geometry. */
+const SUPPORTED_ENTITIES = ["POLYLINE", "3DFACE"];
+
 /**
- * Parse a DXF document and flatten its polyface meshes into triangle vertices, recentred
- * if the file's coordinates outrun float32.
+ * dxf-parser pads 3DFACE vertex lists with an empty object, and drops coordinates it
+ * cannot complete, so points have to be checked rather than trusted.
+ */
+const isCompletePoint = (point: { x?: number; y?: number; z?: number } | undefined) =>
+  !!point &&
+  Number.isFinite(point.x) &&
+  Number.isFinite(point.y) &&
+  Number.isFinite(point.z);
+
+/**
+ * Flatten indexed triangles into raw vertex positions.
+ *
+ * The reversal flips winding, which is the convention this importer has always used;
+ * applying it to a concatenation of contiguous triples reverses each triple as well as
+ * their order, so every triangle is flipped consistently.
+ */
+const flattenTriangles = (vertices: number[][], indices: number[][]) =>
+  (indices.flat().reverse() as number[]).map(index => vertices[index]).flat() as number[];
+
+/** Explain an import that produced nothing, naming what the file actually held. */
+const describeUnsupportedContent = (parsed: Dxf) => {
+  const present = [...new Set(parsed.entities.map(entity => entity.type))].filter(Boolean);
+
+  if (present.length === 0) {
+    return "This DXF file contains no entities to import.";
+  }
+  return (
+    `No importable geometry found in this DXF file. It contains ${present.sort().join(", ")}, ` +
+    `and this importer reads ${SUPPORTED_ENTITIES.join(" and ")} entities. ` +
+    `Re-exporting the drawing as a 3D mesh usually resolves this.`
+  );
+};
+
+/**
+ * Parse a DXF document and flatten its meshes into triangle vertices, recentred if the
+ * file's coordinates outrun float32.
  *
  * Throws a descriptive Error for input that cannot be read: dxf-parser raises a bare
  * scanner error on any group code it doesn't recognise and returns null for input it
@@ -90,10 +127,12 @@ export function decodeDxf(data: string): DecodedDxf {
     throw new Error("Could not read DXF file: no ENTITIES section was found.");
   }
 
-  // Decode every polyface mesh before computing the offset: it has to be shared by all of
-  // them, since a per-surface offset would collapse each onto its own origin and scatter
-  // the model.
-  const meshes = parsed.entities.filter(x => x.type === "POLYLINE").map(polyline => {
+  // Decode every mesh before computing the offset: it has to be shared by all of them,
+  // since a per-surface offset would collapse each onto its own origin and scatter the
+  // model.
+  const meshes: DecodedMesh[] = [];
+
+  parsed.entities.filter(x => x.type === "POLYLINE").forEach(polyline => {
     const vertices = [] as number[][];
     const indices = [] as number[][];
     polyline.vertices.forEach(vertex => {
@@ -114,10 +153,37 @@ export function decodeDxf(data: string): DecodedDxf {
       }
     });
 
-    const positions = (indices.flat().reverse() as number[])
-      .map(index => vertices[index]).flat() as number[];
-    return { layer: polyline.layer, positions };
+    meshes.push({ layer: polyline.layer, positions: flattenTriangles(vertices, indices) });
   });
+
+  // 3DFACE is how most CAD tools export a plain triangulated surface, and each entity is
+  // a single face rather than a whole mesh — so they are merged per layer instead of
+  // becoming one Surface each, which would leave a model of thousands of one-triangle
+  // surfaces that no material could sensibly be assigned to.
+  const facesByLayer = new Map<string, { vertices: number[][]; indices: number[][] }>();
+  parsed.entities.filter(x => x.type === "3DFACE").forEach(face => {
+    const corners = (face.vertices ?? []).filter(isCompletePoint);
+    if (corners.length < 3) return;
+
+    const layer = face.layer;
+    if (!facesByLayer.has(layer)) facesByLayer.set(layer, { vertices: [], indices: [] });
+    const target = facesByLayer.get(layer)!;
+
+    const base = target.vertices.length;
+    corners.forEach(corner => target.vertices.push([corner.x, corner.y, corner.z!]));
+    target.indices.push([base, base + 1, base + 2]);
+    if (corners.length >= 4) {
+      target.indices.push([base, base + 2, base + 3]);
+    }
+  });
+
+  facesByLayer.forEach(({ vertices, indices }, layer) => {
+    meshes.push({ layer, positions: flattenTriangles(vertices, indices) });
+  });
+
+  if (meshes.length === 0) {
+    throw new Error(describeUnsupportedContent(parsed));
+  }
 
   const offset = recenteringOffset(meshes.flatMap(mesh => mesh.positions));
 

--- a/src/import-handlers/dxf.ts
+++ b/src/import-handlers/dxf.ts
@@ -169,7 +169,7 @@ export interface ExtendedData {
 
 export type ApplicationName = string;
 
-export type EntityType = "LINE"|"LWPOLYLINE"|"POLYLINE";
+export type EntityType = "LINE"|"LWPOLYLINE"|"POLYLINE"|"3DFACE";
 
 export interface Vertex {
   x:                     number;


### PR DESCRIPTION
> **Stacked on #94** (→ #93 → #92). Each retargets automatically as the one below merges.

The last gap from the dxf-parser triage. Two related changes.

## 1. An import that finds nothing now says so

A DXF holding nothing this importer reads produced an empty Room and no message — the user watched an import "succeed" and nothing appear. It now throws, naming what the file actually contains:

> No importable geometry found in this DXF file. It contains LINE, LWPOLYLINE, and this importer reads POLYLINE and 3DFACE entities. Re-exporting the drawing as a 3D mesh usually resolves this.

That puts the answer in the message rather than in a debugger. LINE, LWPOLYLINE and INSERT/blocks remain unsupported — but a file containing only those now explains itself.

## 2. 3DFACE support

3DFACE is how most CAD tools export a plain triangulated surface, and it was dropped entirely, so those files imported as *nothing*. Now read, with quads split into two triangles like the polyface path.

**Faces are merged per layer**, not one Surface per face. A 3DFACE is a single face; one Surface each would leave a model of thousands of one-triangle surfaces that no material could sensibly be assigned to. Layer stays the grouping unit, consistent with how POLYLINE already imports.

## Two upstream defects I had to design around

I checked `dxf-parser`'s 3DFACE handling against real fixtures before writing any of this, and it is broken in two distinct ways:

```
plain quad (next entity follows):  5 vertices  [...4 real..., {}]   <- phantom
quad + Revit xdata (1001):         3 vertices                       <- 4th dropped
```

**The phantom vertex** is handled: points are validated rather than trusted, so the empty object can't become a NaN corner and poison the geometry.

**The dropped vertex** is not repairable here. `parse3dFaceVertices` returns without pushing the in-progress vertex when a non-vertex group code follows it — which is exactly what Revit writes ([#112](https://github.com/gdsestimating/dxf-parser/issues/112)). The data is gone before CRAM sees it, and a truncated quad is indistinguishable from a genuine triangle, so there is nothing to detect. A quad from such a file imports as a triangle — a hole.

I've pinned that in a test rather than leaving it as folklore:

```
it('loses the fourth corner of a quad carrying trailing xdata (upstream #112)')
```

It documents the gap, and will **fail if upstream ever fixes it**, prompting removal.

This is worth a decision, and I don't think it's mine to make: partial 3DFACE support is a large net win over importing nothing, but it does mean Revit-exported quads arrive with holes. The alternatives are patching `dxf-parser` locally (needs `patch-package`, which isn't a dependency today) or upstreaming the fix — the maintainer was receptive to jbroll's perf PRs when they came with evidence, and this one is four lines. Happy to open it if you want.

## Testing

Ten new cases, **all ten fail without this change**, and the 21 existing DXF tests pass untouched:

```
× imports a triangular face
× splits a quad face into two triangles
× discards the empty trailing vertex the parser appends
× merges faces on the same layer into one surface
× keeps separate layers as separate surfaces
× imports alongside polyface meshes
× loses the fourth corner of a quad carrying trailing xdata (upstream #112)
× names the entity types it found instead of importing an empty room
× says what the importer does read
× reports an entities section with nothing in it
```

Full suite: **94 files, 1896 tests, 0 failures.** `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
