### PR TITLE
refactor(acoustics): drop the dead complex dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "ambisonics": "github:10log/TSAmbisonics",
         "beam-trace": "github:10log/BeamTrace2D#master",
         "chroma-js": "^3.2.0",
-        "complex": "^3.0.1",
         "d3": "^7.9.0",
         "dxf-parser": "^1.0.0-alpha.2",
         "es-abstract": "^1.24.1",
@@ -13262,11 +13261,6 @@
       "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/complex": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/complex/-/complex-3.0.1.tgz",
-      "integrity": "sha512-oInXNu3gaWt5NOW9/lpFyA8Sl0jpzNd3eWP5AI15v5m2QsdFsZqO2dn+uiqQHlub5vln5MD9C19dshbo8+amVg=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "ambisonics": "github:10log/TSAmbisonics",
     "beam-trace": "github:10log/BeamTrace2D#master",
     "chroma-js": "^3.2.0",
-    "complex": "^3.0.1",
     "d3": "^7.9.0",
     "dxf-parser": "^1.0.0-alpha.2",
     "es-abstract": "^1.24.1",

--- a/src/compute/acoustics/__tests__/complex.spec.ts
+++ b/src/compute/acoustics/__tests__/complex.spec.ts
@@ -151,6 +151,31 @@ describe('Complex', () => {
     });
   });
 
+  describe('angle', () => {
+    it('is zero along the positive real axis', () => {
+      expect(new Complex({ real: 5, imag: 0 }).angle()).toBe(0);
+    });
+
+    it('is a quarter turn along the positive imaginary axis', () => {
+      expect(new Complex({ real: 0, imag: 5 }).angle()).toBeCloseTo(Math.PI / 2, 12);
+    });
+
+    it('is pi along the negative real axis', () => {
+      expect(new Complex({ real: -5, imag: 0 }).angle()).toBeCloseTo(Math.PI, 12);
+    });
+
+    it('resolves the quadrant rather than folding onto a half plane', () => {
+      // atan(imag/real) alone cannot tell these apart; atan2 can.
+      expect(new Complex({ real: -1, imag: -1 }).angle()).toBeCloseTo(-3 * Math.PI / 4, 12);
+      expect(new Complex({ real: 1, imag: 1 }).angle()).toBeCloseTo(Math.PI / 4, 12);
+    });
+
+    it('agrees with the polar form it was built from', () => {
+      const arg = 0.7;
+      expect(new Complex({ radius: 2, arg }).angle()).toBeCloseTo(arg, 12);
+    });
+  });
+
   describe('swap', () => {
     it('swaps real and imaginary parts', () => {
       const c = new Complex({ real: 3, imag: 4 });

--- a/src/compute/acoustics/__tests__/porous.spec.ts
+++ b/src/compute/acoustics/__tests__/porous.spec.ts
@@ -1,0 +1,87 @@
+import { rigidBackedPorousAbsorber } from '../porous';
+
+/**
+ * Characterisation tests for the Delany–Bazley rigid-backed porous absorber.
+ *
+ * The expected values were captured from the implementation as it stood when it used the
+ * `complex` npm package, so they pin the arithmetic across the move to CRAM's own Complex
+ * class. They are golden values, not independently derived from the literature: their job
+ * is to prove the numbers did not move.
+ *
+ * Every case passes frequencies explicitly — the function assigns onto its module-level
+ * defaults object, so an omitted frequency list would leak between calls.
+ */
+const params = {
+  speed: 340,
+  density: 1.21,
+  flowResistivity: 50000,
+  thickness: 0.0254,
+  frequencies: [125, 250, 500, 1000, 2000, 4000],
+};
+
+const ABSORPTION = [
+  0.11395487712222307, 0.2198418298972341, 0.38570542366166827,
+  0.5857543793781488, 0.750218057164671, 0.8316282986294593,
+];
+
+const MAGNITUDE = [
+  0.9412996987558091, 0.8832656282810771, 0.7837694663217825,
+  0.6436191580599907, 0.49978189526565375, 0.410331209354761,
+];
+
+const PHASE = [
+  -0.005971320357903986, -0.00638087841427589, 0.0028082250527685314,
+  0.04616043387651554, 0.17584555324627343, 0.4227903164812754,
+];
+
+describe('rigidBackedPorousAbsorber', () => {
+  it('returns the frequencies it was given', () => {
+    expect(rigidBackedPorousAbsorber({ ...params }).frequency).toEqual(params.frequencies);
+  });
+
+  it('reproduces the known absorption coefficients', () => {
+    const { absorption } = rigidBackedPorousAbsorber({ ...params });
+
+    absorption.forEach((value, i) => expect(value).toBeCloseTo(ABSORPTION[i], 12));
+  });
+
+  it('reproduces the known reflection magnitudes', () => {
+    const { reflection } = rigidBackedPorousAbsorber({ ...params });
+
+    reflection.magnitude.forEach((value, i) => expect(value).toBeCloseTo(MAGNITUDE[i], 12));
+  });
+
+  it('reproduces the known reflection phases', () => {
+    const { reflection } = rigidBackedPorousAbsorber({ ...params });
+
+    reflection.phase.forEach((value, i) => expect(value).toBeCloseTo(PHASE[i], 12));
+  });
+
+  it('absorbs more at higher frequencies, as a porous absorber must', () => {
+    const { absorption } = rigidBackedPorousAbsorber({ ...params });
+
+    for (let i = 1; i < absorption.length; i++) {
+      expect(absorption[i]).toBeGreaterThan(absorption[i - 1]);
+    }
+  });
+
+  it('keeps absorption and reflection magnitude physical', () => {
+    const { absorption, reflection } = rigidBackedPorousAbsorber({ ...params });
+
+    absorption.forEach((value) => {
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThanOrEqual(1);
+    });
+    reflection.magnitude.forEach((value) => {
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThanOrEqual(1);
+    });
+  });
+
+  it('absorbs more as the material gets thicker', () => {
+    const thin = rigidBackedPorousAbsorber({ ...params, thickness: 0.0254 });
+    const thick = rigidBackedPorousAbsorber({ ...params, thickness: 0.1016 });
+
+    expect(thick.absorption[0]).toBeGreaterThan(thin.absorption[0]);
+  });
+});

--- a/src/compute/acoustics/complex.ts
+++ b/src/compute/acoustics/complex.ts
@@ -46,6 +46,14 @@ export class Complex {
   }
 
   /**
+   * The argument of the complex number — its phase angle in radians, measured from the
+   * positive real axis and in the range (-pi, pi].
+   */
+  public angle(): number {
+    return Math.atan2(this.imag, this.real);
+  }
+
+  /**
    * Swaps the real part and the imaginary part.
    */
   public swap(): Complex {

--- a/src/compute/acoustics/porous.ts
+++ b/src/compute/acoustics/porous.ts
@@ -1,10 +1,18 @@
 // @ts-nocheck
 import { linspace } from "./util/linspace";
-import complex from "complex";
+import { Complex } from "./complex";
 
 const { PI: pi, tanh } = Math;
 const coth = (x: number) => 1 / tanh(x);
-const ccoth = (x: complex) => new complex(coth(x.real), coth(x.im));
+
+/** Lift a real scalar into the complex plane. */
+const re = (value: number) => new Complex({ real: value, imag: 0 });
+
+// NOTE: this takes coth of the real and imaginary parts independently, which is not the
+// complex hyperbolic cotangent that the Delany–Bazley surface impedance calls for.
+// Preserved exactly as it was — correcting it would move every absorption coefficient
+// this function returns, which is a change to the acoustics rather than to the plumbing.
+const ccoth = (x: Complex) => new Complex({ real: coth(x.real), imag: coth(x.imag) });
 
 export interface RigidBackedPorousAbsorberParams {
   speed?: number;
@@ -31,35 +39,37 @@ export function rigidBackedPorousAbsorber(params: RigidBackedPorousAbsorberParam
   const X = f.map((f) => (ρ * f) / σ);
 
   // characteristic impedance
-  const zc = X.map((X) => new complex(ρ * c * (1 + 0.0571 * X ** -0.754), ρ * c * (-0.087 * X ** -0.732)));
+  const zc = X.map((X) => new Complex({
+    real: ρ * c * (1 + 0.0571 * X ** -0.754),
+    imag: ρ * c * (-0.087 * X ** -0.732)
+  }));
 
   // complex wave number
   const k = X.map((X, i) => {
     const multiplier = ((2 * pi) / c) * f[i];
-    return new complex(multiplier * +(1 + 0.0978 * X ** -0.7), multiplier * -(0 + 0.189 * X ** -0.595));
+    return new Complex({
+      real: multiplier * +(1 + 0.0978 * X ** -0.7),
+      imag: multiplier * -(0 + 0.189 * X ** -0.595)
+    });
   });
 
   // propogation constant
-  const γ = k.map((k) => new complex(-k.im, k.real));
+  const γ = k.map((k) => new Complex({ real: -k.imag, imag: k.real }));
 
   // surface impedance
-  const z = zc.map((zc, i) => zc.clone().mult(ccoth(γ[i].clone().mult(l))));
+  // Complex is immutable, so the defensive clones the previous library needed are gone.
+  const z = zc.map((zc, i) => zc.multiply(ccoth(γ[i].multiply(re(l)))));
 
   // reflection factor
-  const R = z.map((z) => {
-    // return z.sub(Z0).divide(z.add(Z0));
-    let sub = z.clone().sub(Z0);
-    let add = z.clone().add(Z0);
-    return sub.divide(add);
-  });
+  const R = z.map((z) => z.subtract(re(Z0)).divide(z.add(re(Z0))));
 
   // normal incidence absorption coefficient
-  const a = R.map((R) => 1 - R.abs() ** 2);
+  const a = R.map((R) => 1 - R.absolute() ** 2);
 
   return {
     frequency: f,
     reflection: {
-      magnitude: R.map((R) => R.abs()),
+      magnitude: R.map((R) => R.absolute()),
       phase: R.map((R) => R.angle())
     },
     absorption: a

--- a/src/types/modules.d.ts
+++ b/src/types/modules.d.ts
@@ -1,21 +1,5 @@
 // Type declarations for modules without types
 
-declare module 'complex' {
-  export default class Complex {
-    real: number;
-    imag: number;
-    constructor(real?: number, imag?: number);
-    static from(obj: { real: number; imag: number }): Complex;
-    add(other: Complex): Complex;
-    sub(other: Complex): Complex;
-    mul(other: Complex): Complex;
-    div(other: Complex): Complex;
-    abs(): number;
-    arg(): number;
-    conjugate(): Complex;
-  }
-}
-
 declare module 'three.meshline' {
   import * as THREE from 'three';
 


### PR DESCRIPTION
Second Tier 1 item from the dependency triage. Independent of the DXF stack — targets `varese-dev` directly.

## Why

`porous.ts` was the only consumer of the `complex` npm package. Upstream ([arian/Complex](https://github.com/arian/Complex)) was last touched **November 2015** — ten years dead, 26 stars.

CRAM already ships its own `Complex` class, used by fft, window, and complex-array, with a ~250-line test suite. So the project carried **two complex-number implementations**, one of them abandoned.

## Not a rename

The APIs look interchangeable but the semantics differ, which is most of the risk here:

| | `complex` | `Complex` |
|---|---|---|
| mutation | mutates and returns `this` | immutable, returns new |
| constructor | `new complex(re, im)` | `new Complex({real, imag})` |
| scalars | coerced automatically | not accepted |
| naming | `.im` `.abs()` `.mult` `.sub` | `.imag` `.absolute()` `.multiply` `.subtract` |

The mutation difference is why every call site had a defensive `.clone()` — those are now gone. Scalar operands are lifted explicitly through a small `re()` helper rather than relying on implicit coercion.

`Complex` gains `angle()`, the one operation `porous.ts` needed that it lacked. It's `atan2`-based, so it resolves the quadrant rather than folding onto a half plane, and there are tests for exactly that.

## How the arithmetic is protected

This is acoustics, not plumbing — a silent numerical shift in Delany–Bazley impedance would be invisible and wrong. `porous.ts` had **no tests at all**.

So I wrote characterisation tests **against the old implementation first**: golden absorption, reflection magnitude, and phase values captured from `complex` and asserted to 12 decimal places. They passed before the swap and are unchanged after it.

```
absorption: [0.11395487712222307, 0.2198418298972341, 0.38570542366166827, ...]
magnitude:  [0.9412996987558091, 0.8832656282810771, 0.7837694663217825, ...]
phase:      [-0.005971320357903986, -0.00638087841427589, 0.0028082250527685314, ...]
```

Plus property-style checks that don't depend on the goldens: absorption rises with frequency, absorption and reflection magnitude stay within [0, 1], and a thicker absorber absorbs more.

## Verification

- Golden values **byte-identical** across the swap
- Confirmed the package is genuinely unused by **removing it from `node_modules` outright**, then running the suite and `build:lib` — not just grepping for imports
- `build:lib` exits 0; the dts warnings it prints are pre-existing and in untouched files (`bvhtree_old.js`, `OrbitControls.js`, `global-vars.ts`), none mentioning `complex`
- Full suite: **94 files, 1877 tests, 0 failures**. `tsc --noEmit` clean on both touched files.
- Lockfile drops `node_modules/complex` entirely

## Two things I found and deliberately did not change

Both are real, both would alter behaviour, so they're flagged rather than folded into a dependency swap:

1. **`ccoth` is not the complex hyperbolic cotangent.** It applies `coth` to the real and imaginary parts independently, but `coth(a+bi) ≠ coth(a) + coth(b)i`. The Delany–Bazley surface impedance calls for the genuine complex `coth`. Correcting it would move every absorption coefficient this function returns. There's now a `NOTE` comment at the definition. Worth a decision — I'd treat it as an acoustics bug, but not one to fix silently under a refactor.

2. **`Object.assign(defaults, params)` mutates the module-level defaults object**, so parameters leak between calls — notably the 10,000-entry default frequency list. The new tests all pass frequencies explicitly to avoid depending on it. A one-word fix (`Object.assign({}, defaults, params)`), but it is a behaviour change.

Happy to take either as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
