### PR TITLE
fix(types): stop declaring the meshline API that corrupts geometry

### DIFF
--- a/src/compute/__tests__/three-meshline.spec.ts
+++ b/src/compute/__tests__/three-meshline.spec.ts
@@ -1,0 +1,74 @@
+import * as THREE from 'three';
+import { MeshLine } from 'three.meshline';
+
+/**
+ * Why the setPoints declaration in src/types/modules.d.ts only accepts Float32Array.
+ *
+ * three.meshline reaches three through require(), which resolves to three's CommonJS
+ * build, while CRAM imports it and gets the ESM build. three's exports map makes those
+ * two separate modules with two separate Vector3 classes, so the library's
+ * `points[0] instanceof THREE.Vector3` guard can never match a Vector3 constructed here.
+ * A Vector3 array therefore falls through to the flat-number branch and is read as
+ * coordinates, yielding NaN positions rather than a line.
+ *
+ * These tests deliberately exercise the real library against real three — no mocks. If
+ * the Vector3 case ever starts producing sane geometry, the dependency has been fixed or
+ * replaced and the type can be widened again.
+ */
+describe('three.meshline setPoints', () => {
+  const path = [
+    [0, 0, 0],
+    [1, 0, 0],
+    [1, 1, 0],
+  ];
+
+  const positionsOf = (line: MeshLine) =>
+    Array.from(((line as any).attributes.position.array as ArrayLike<number>));
+
+  it('builds correct geometry from a Float32Array', () => {
+    const line = new MeshLine();
+    line.setPoints(new Float32Array(path.flat()));
+
+    // MeshLine doubles every point to give the ribbon its two edges.
+    expect((line as any).attributes.position.count).toBe(path.length * 2);
+    expect(positionsOf(line).every((n) => Number.isFinite(n))).toBe(true);
+  });
+
+  it('places the doubled vertices on the original points', () => {
+    const line = new MeshLine();
+    line.setPoints(new Float32Array(path.flat()));
+
+    expect(positionsOf(line)).toEqual([
+      0, 0, 0, 0, 0, 0,
+      1, 0, 0, 1, 0, 0,
+      1, 1, 0, 1, 1, 0,
+    ]);
+  });
+
+  it('accepts the empty case used to clear a path', () => {
+    const line = new MeshLine();
+
+    expect(() => line.setPoints(new Float32Array(0))).not.toThrow();
+    expect((line as any).attributes.position.count).toBe(0);
+  });
+
+  // The reason the declared type excludes Vector3[]. Not aspirational — this is what the
+  // installed version does today, and it fails silently.
+  it('silently corrupts a Vector3 array, which is why the type forbids one', () => {
+    const line = new MeshLine();
+    const vectors = path.map(([x, y, z]) => new THREE.Vector3(x, y, z));
+
+    // @ts-expect-error - passing the shape the declaration deliberately rejects
+    line.setPoints(vectors);
+
+    const positions = positionsOf(line);
+    expect((line as any).attributes.position.count).not.toBe(vectors.length * 2);
+    expect(positions.every((n) => Number.isFinite(n))).toBe(false);
+  });
+
+  it('does not share a three instance with CRAM, which is the root cause', () => {
+    // MeshLine extends THREE.BufferGeometry in its own source, yet is not an instance of
+    // the BufferGeometry CRAM imports — two copies of three, two class identities.
+    expect(new MeshLine() instanceof THREE.BufferGeometry).toBe(false);
+  });
+});

--- a/src/compute/beam-trace/index.ts
+++ b/src/compute/beam-trace/index.ts
@@ -53,7 +53,7 @@ import FileSaver from "file-saver";
 // Helper to create a highlighted path line (same as ImageSourceSolver)
 function createHighlightLine(): THREE.Mesh {
   const line = new MeshLine();
-  line.setPoints([]);
+  line.setPoints(new Float32Array(0));
   const material = new MeshLineMaterial({
     lineWidth: 0.1,
     color: 0xff0000,
@@ -486,7 +486,7 @@ export class BeamTraceSolver extends Solver {
   // beam contains polygonPath which is the sequence of polygon IDs for reflections
   private highlightVirtualSourcePath(beam: BeamVisualizationData & { polygonPath: number[] }) {
     // Clear previous selections
-    (this.selectedPath.geometry as MeshLine).setPoints([]);
+    (this.selectedPath.geometry as MeshLine).setPoints(new Float32Array(0));
     this.clearSelectedBeams();
 
     const colorHex = getOrderColor(beam.reflectionOrder, this.maxReflectionOrder);
@@ -2005,7 +2005,7 @@ export class BeamTraceSolver extends Solver {
     this.clearLevelTimeProgressionData();
 
     // Clear highlighted path and beams
-    (this.selectedPath.geometry as MeshLine).setPoints([]);
+    (this.selectedPath.geometry as MeshLine).setPoints(new Float32Array(0));
     this.clearSelectedBeams();
 
     renderer.needsToRender = true;
@@ -2224,7 +2224,7 @@ export class BeamTraceSolver extends Solver {
     const path = sortedPaths[pathIndex];
 
     // Clear previous selections
-    (this.selectedPath.geometry as MeshLine).setPoints([]);
+    (this.selectedPath.geometry as MeshLine).setPoints(new Float32Array(0));
     this.clearSelectedBeams();
 
     // Get the order-based color for this path
@@ -2293,7 +2293,7 @@ export class BeamTraceSolver extends Solver {
 
   // Clear the current path highlight
   clearPathHighlight() {
-    (this.selectedPath.geometry as MeshLine).setPoints([]);
+    (this.selectedPath.geometry as MeshLine).setPoints(new Float32Array(0));
     this.clearSelectedBeams();
     renderer.needsToRender = true;
   }

--- a/src/compute/raytracer/image-source/index.ts
+++ b/src/compute/raytracer/image-source/index.ts
@@ -20,9 +20,8 @@ import {
 } from "../../shared/export-playback";
 
 function createLine(){
-  let points: THREE.Vector3[] = [];
   const line = new MeshLine();
-  line.setPoints(points);
+  line.setPoints(new Float32Array(0));
   const material = new MeshLineMaterial({
     lineWidth: 0.1,
     color: 0xff0000,

--- a/src/types/modules.d.ts
+++ b/src/types/modules.d.ts
@@ -21,7 +21,24 @@ declare module 'three.meshline' {
 
   export class MeshLine extends THREE.BufferGeometry {
     setGeometry(geometry: THREE.BufferGeometry | Float32Array | THREE.Vector3[]): void;
-    setPoints(points: Float32Array | THREE.Vector3[]): void;
+
+    /**
+     * Flat [x,y,z, x,y,z, ...] vertex positions.
+     *
+     * three.meshline accepts a THREE.Vector3[] at runtime, but that path is unusable
+     * here and is deliberately not declared. It is guarded by
+     * `points[0] instanceof THREE.Vector3`, and the THREE that guard closes over is the
+     * CommonJS build the library pulls in via require(), while CRAM imports the ESM
+     * build. three's exports map makes those two different modules with two different
+     * Vector3 classes, so the check always fails and the array falls through to the
+     * flat-number branch — silently producing NaN positions instead of a line:
+     *
+     *   setPoints([Vector3(0,0,0), Vector3(1,0,0), Vector3(1,1,0)])
+     *     -> position.count 2, array [null,null,null,null,null,null]
+     *
+     * Passing a Float32Array avoids the guard entirely and is correct.
+     */
+    setPoints(points: Float32Array): void;
   }
 
   export class MeshLineMaterial extends THREE.ShaderMaterial {


### PR DESCRIPTION
Follow-up to the `three.meshline` runtime check. Independent — targets `varese-dev` directly.

## The check's actual result

The compatibility worry was unfounded: **three.meshline 1.4.0 works fine on three@0.185.1.** Geometry builds correctly, attributes are right, no NaN, the material constructs with all its uniforms, a mesh lives in a scene. None of the r125-era issues apply. No migration is needed on those grounds.

But the probe turned up something else.

## The bug

`instanceof THREE.BufferGeometry` returns **false** for a `MeshLine`, despite its source saying `class MeshLine extends THREE.BufferGeometry`.

three ships a split exports map:

```json
"exports": { ".": { "import": "./build/three.module.js", "require": "./build/three.cjs" } }
```

three.meshline reaches three through `require()` and gets the CommonJS build; CRAM imports it and gets the ESM build. Two modules, two sets of classes.

That matters because of this guard inside `setPoints`:

```js
if (points.length && points[0] instanceof THREE.Vector3) {   // ← the CJS THREE
```

It can never match a `Vector3` constructed in CRAM. So a Vector3 array falls through to the flat-number branch and gets read as raw coordinates:

```
Vector3[]    -> position.count 2   [null,null,null,null,null,null]
Float32Array -> position.count 6   [0,0,0, 0,0,0, 1,0,0, 1,0,0, 1,1,0, 1,1,0]
```

No error. No warning. Just a line that isn't there.

And `src/types/modules.d.ts` was **advertising that overload** — so the declared API pointed straight at the trap.

## The fix

Narrow the declaration to `Float32Array`, which sidesteps the guard entirely and is the correct input.

That let the compiler find every affected call site rather than me grepping for them — six, all in `beam-trace` and `image-source`. Every one passed an **empty** array to clear a path, which short-circuits before the broken guard, so **none were producing bad geometry today**. They were one edit away from it. They now pass `Float32Array(0)`.

Worth noting the codebase was otherwise `tsc --noEmit` clean, so those six were the complete set.

## Testing

Five tests exercising the real library against real three — no mocks — including the corruption itself, so the justification for the narrow type lives beside the type rather than in a commit message. If the Vector3 case ever starts behaving, the dependency has been fixed or replaced and the declaration can widen again.

Full suite: **94 files, 1870 tests, 0 failures.** `tsc --noEmit` clean. `build:lib` exits 0.

## Scope

This does not fix the duplicate-three instance underneath — that would mean migrating to `pmndrs/meshline`, which the runtime check says isn't otherwise justified. This closes the one place where the problem can reach CRAM.

I'd also now **demote `three.meshline` from Tier 1**: it works, and the specific hazard it posed is contained here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
